### PR TITLE
Give the GitHub profile card its own section above the calendar

### DIFF
--- a/src/app/(pages)/github/page.jsx
+++ b/src/app/(pages)/github/page.jsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import GitHubCalendar from "react-github-calendar";
-import { Comment, Function, Section } from "@/components";
+import { Comment, Function, Section, Type } from "@/components";
 import { Box, Button, Typography } from "@mui/material";
 
 const theme = {
@@ -9,47 +9,55 @@ const theme = {
 
 export default function Page() {
   return (
-    <Section sx={{ flex: "1 1 0px" }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        <Comment>I definitely don&apos;t have any </Comment>
-        <Function>commit</Function>
-        <Comment>ment issues</Comment>
-      </Typography>
-      {/* The same SVG card served to the csalinas-dev profile README, rendered
-          straight from /api/github/card. Loading it as an image (rather than
-          inlining the markup) keeps the card's embedded font and styles inside
-          the image sandbox, and lets the browser cache it independently. */}
-      <Box
-        component="img"
-        src="/api/github/card"
-        alt="GitHub profile card for Christopher Salinas Jr. — contribution streak, totals, and most-used languages"
-        sx={{
-          alignSelf: "flex-start",
-          height: "auto",
-          marginBottom: "2rem",
-          maxWidth: "100%",
-          width: 760,
-        }}
-      />
-      <GitHubCalendar
-        username="csalinas-dev"
-        colorScheme="dark"
-        theme={theme}
-        blockSize={16}
-      />
-      <div style={{ marginTop: "2rem" }}>
-        <Button
-          color="primary"
-          component={Link}
-          href="https://github.com/csalinas-dev"
-          rel="noopener noreferrer"
-          target="_blank"
-          variant="contained"
-        >
-          <i className="fa-brands fa-github" />
-          &nbsp;Visit My GitHub
-        </Button>
-      </div>
-    </Section>
+    <>
+      <Section sx={{ pb: 0 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          <Comment>The </Comment>
+          <Type>README</Type>
+          <Comment> version of me</Comment>
+        </Typography>
+        {/* The same SVG card served to the csalinas-dev profile README, rendered
+            straight from /api/github/card. Loading it as an image (rather than
+            inlining the markup) keeps the card's embedded font and styles inside
+            the image sandbox, and lets the browser cache it independently. */}
+        <Box
+          component="img"
+          src="/api/github/card"
+          alt="GitHub profile card for Christopher Salinas Jr. — contribution streak, totals, and most-used languages"
+          sx={{
+            alignSelf: "flex-start",
+            height: "auto",
+            maxWidth: "100%",
+            width: 760,
+          }}
+        />
+      </Section>
+      <Section sx={{ flex: "1 1 0px" }}>
+        <Typography variant="h4" component="h2" gutterBottom>
+          <Comment>I definitely don&apos;t have any </Comment>
+          <Function>commit</Function>
+          <Comment>ment issues</Comment>
+        </Typography>
+        <GitHubCalendar
+          username="csalinas-dev"
+          colorScheme="dark"
+          theme={theme}
+          blockSize={16}
+        />
+        <div style={{ marginTop: "2rem" }}>
+          <Button
+            color="primary"
+            component={Link}
+            href="https://github.com/csalinas-dev"
+            rel="noopener noreferrer"
+            target="_blank"
+            variant="contained"
+          >
+            <i className="fa-brands fa-github" />
+            &nbsp;Visit My GitHub
+          </Button>
+        </div>
+      </Section>
+    </>
   );
 }


### PR DESCRIPTION
Follow-up to #82.

The profile card and the contribution calendar were sharing a single `<Section>` under the "commitment issues" heading, so the card read as though it belonged to the calendar. They are now two sections, each with its own heading, card first:

- `// The README version of me` — the profile card
- `// I definitely don't have any commitment issues` — the calendar and the GitHub link

The calendar heading drops from `<h1>` to `<h2>`, since the card section now owns the page's `<h1>`.

Verified in Chrome at `/github`: two distinct sections, card above the calendar, spacing consistent with the rest of the site. `npm run lint` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
