### PR TITLE
content(wordle): add ALIAS and OASIS without remapping past answers

### DIFF
--- a/src/app/(pages)/games/wordleverse/(game)/_lib/random.js
+++ b/src/app/(pages)/games/wordleverse/(game)/_lib/random.js
@@ -1,6 +1,37 @@
 import words from "@/data/words.json";
 
 /**
+ * Size of the answer pool for dates before {@link EXPANSION_SEED}.
+ *
+ * The daily answer is picked as `words[floor(random(seed) * poolSize)]`, so the
+ * pool size — not just the contents — decides which word a date maps to.
+ * Growing `words.json` would therefore rewrite the answer for every date ever
+ * played, including past dates, which stay replayable via
+ * `/games/wordleverse?date=YYYY-MM-DD`. Pinning older dates to the original
+ * 2319-word prefix keeps every historical answer exactly where it was.
+ *
+ * Words added after that prefix are still accepted as guesses immediately
+ * (`submitGuess` validates against the whole list) and can still come up in
+ * "play again" — they just aren't reachable as a *daily* answer until the
+ * expansion date.
+ *
+ * Adding more words later: append them to the end of `words.json`, then bump
+ * this count to the current length and set a new future expansion date. Never
+ * insert or reorder — that breaks the prefix and every date with it.
+ * @type {number}
+ */
+const ORIGINAL_POOL_SIZE = 2319;
+
+/**
+ * Date seed (yyyymmdd, see {@link getDateSeed}) on which the full word list
+ * becomes eligible for the daily answer. Must be far enough ahead of the
+ * deploy that no date is played under the old pool and re-derived under the
+ * new one.
+ * @type {number}
+ */
+const EXPANSION_SEED = 20260901;
+
+/**
  * Generates a seed based on a date
  * @param {Date|string} date - Date object or string in format 'yyyy-mm-dd'
  * @returns {number} - Seed value
@@ -33,6 +64,11 @@ export const pseudoRandom = (seed) => {
  */
 export const getRandomWord = (date = new Date()) => {
   const seed = getDateSeed(date);
-  const randomIndex = Math.floor(pseudoRandom(seed) * words.length);
+
+  // Older dates draw from the original prefix of the list so their answers
+  // never shift as words are appended — see ORIGINAL_POOL_SIZE.
+  const poolSize = seed < EXPANSION_SEED ? ORIGINAL_POOL_SIZE : words.length;
+
+  const randomIndex = Math.floor(pseudoRandom(seed) * poolSize);
   return words[randomIndex];
 };

--- a/src/app/(pages)/games/wordleverse/CLAUDE.md
+++ b/src/app/(pages)/games/wordleverse/CLAUDE.md
@@ -48,6 +48,10 @@ If a date exists in both places (the player played it on another device while si
 
 `getRandomWord(date)` in `_lib/random.js` uses a deterministic seed derived from the date. Same word for all users on the same date. No state or network call needed.
 
+The word list is `src/data/words.json` — it is **both** the answer pool and the accepted-guess dictionary (`submitGuess` checks `words.includes(guess)`).
+
+**Adding words is not a plain append.** The answer is `words[floor(random(seed) * poolSize)]`, so changing the pool size remaps every date, and past dates are replayable via `?date=`. `random.js` therefore pins dates before `EXPANSION_SEED` to the first `ORIGINAL_POOL_SIZE` entries. To add words: append to the **end** of `words.json` (never insert or reorder), bump `ORIGINAL_POOL_SIZE` to the pre-append length, and set `EXPANSION_SEED` to a date safely after the deploy. New words are accepted as guesses immediately either way.
+
 ## Game State Flow
 
 1. `ContextProvider` mounts → `useMigrateLocalStorage` runs (awaited before game load)

--- a/src/data/words.json
+++ b/src/data/words.json
@@ -2317,5 +2317,7 @@
   "ARTSY",
   "RURAL",
   "SHAVE",
-  "SQUID"
+  "SQUID",
+  "ALIAS",
+  "OASIS"
 ]


### PR DESCRIPTION
Adds **ALIAS** and **OASIS** to Wordleverse. Neither was already in the list; it goes from 2319 to 2321 words.

## The catch

`src/data/words.json` does double duty — it is the answer pool *and* the accepted-guess dictionary (`submitGuess` does `words.includes(guess)`). Appending covers the dictionary side for free.

The answer side is the problem. `getRandomWord` picks:

```js
words[Math.floor(pseudoRandom(getDateSeed(date)) * words.length)]
```

The array **length** is an input to the index math, so changing it remaps every date, not just future ones. Past dates are replayable via `/games/wordleverse?date=YYYY-MM-DD`, so a naive append would quietly hand players a different word than the one everyone else got on that date — and a different word than their own `WordleGame.word` row (the DB copy is per-game, so stored games keep their word, but a *newly opened* past date would disagree with it).

Measured, over the valid 2024-01-01..today range:

```
naive append would change 704/945 historical answers (74.5%)
  2024-01-01: DRILL -> BICEP
  2024-01-02: MANGY -> INLET
  2024-01-03: MAKER -> DIZZY
  2024-01-04: WAXEN -> STOIC
  2024-01-05: USURP -> SCALD
```

## The fix

The new words are appended to the **end** of `words.json`, so every original index is untouched. `getRandomWord` then sizes the pool by date:

```js
const poolSize = seed < EXPANSION_SEED ? ORIGINAL_POOL_SIZE : words.length;
```

- `ORIGINAL_POOL_SIZE = 2319` — dates before the cutover index into the original prefix, so they resolve exactly as before.
- `EXPANSION_SEED = 20260901` — on and after 2026-09-01 the full list is eligible as a daily answer.

The cutover is set a month out deliberately: if it were today, any date played between merge and deploy would be derived under one pool and re-derived under the other. Both constants carry JSDoc explaining the invariant and the procedure for adding words later (append only, bump the count, pick a new future date).

## Verification

Historical answers are byte-identical. A throwaway script (temp dir, not committed) dumped `getRandomWord` for all 945 dates in 2024-01-01..today against the real `random.js` + `words.json`, before and after the change:

```
$ node dump.js <repo> before.txt     # on main
wrote 945 dates -> before.txt
$ node dump.js <repo> after.txt      # on this branch
wrote 945 dates -> after.txt
$ diff before.txt after.txt
diff exit: 0
```

Zero differences across all 945 dates.

Both words are live immediately as guesses, and reachable as daily answers after the cutover:

```
first daily appearance on/after 2026-09-01:
  ALIAS: 2032-04-27
  OASIS: 2031-06-12

accepted as guesses: ALIAS=true OASIS=true
list length: 2321
```

Those dates are far out simply because each word is 1-in-2321 per day — that is the existing seed scheme, not something this change introduces. Both words are also immediately reachable in "play again" random mode and in expert mode's `wordsRemaining` filtering.

`npm run lint` and `npm run build` both pass clean.

## Worth a look

- **`/games/hashtag` also imports `words.json`** (`hashtag/context/random.js`) and seed-shuffles the whole array to build its daily puzzle, so today's hashtag puzzle will change on deploy. There is no past-date replay for hashtag and nothing historical is persisted, so this is a one-day cosmetic churn — but it is out of this issue's scope and left alone deliberately. Say the word if you'd rather pin hashtag to a fixed slice too.
- **The 2026-09-01 cutover is a judgement call.** Pull it earlier if this deploys sooner; just don't set it to a date that could already have been played.
- Unrelated pre-existing nit spotted while reading: `playAgain.js` uses lodash `random(words.length)`, which is inclusive of the upper bound and can return `undefined`. Not touched here.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
