### PR TITLE
feat(EC): interactive board, zoom, colourblind-safe boxes

### DIFF
--- a/src/app/(pages)/games/edge-case/Game.jsx
+++ b/src/app/(pages)/games/edge-case/Game.jsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useCallback, useContext, useMemo } from "react";
+import styled from "@emotion/styled";
+
+import { getResult } from "./_lib";
+import { Board } from "./board";
+import { Announcer, Endgame, Scoreboard, Setup, TurnBanner } from "./components";
+import { Context, drawEdge, newGame, setSetupOpen } from "./context";
+import { playerFor } from "./players";
+import { Toolbar } from "./Toolbar";
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  justify-content: flex-start;
+  padding: 3.5rem 1rem 1.5rem;
+  position: relative;
+  width: 100%;
+`;
+
+// One column, capped at a width where a 9-dot board's tap targets are still
+// comfortable and a phone gets the whole thing edge to edge.
+const Stack = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  max-width: 32rem;
+  width: 100%;
+`;
+
+/**
+ * The local hotseat game — the wiring between the store and the board.
+ *
+ * Everything the board needs is computed here and passed down, which is the
+ * whole point: on one device the player IS whoever is on the clock, so
+ * `youSlot` is `game.turn`. Online (#94), `youSlot` is the slot this browser
+ * joined as and `interactive` becomes `youSlot === game.turn`, and the board
+ * below does not change by a line.
+ */
+export default function Game() {
+  const { state, dispatch } = useContext(Context);
+  const { game, players, playerCount, setupOpen, size } = state;
+
+  const result = useMemo(() => getResult(game), [game]);
+
+  // Hotseat: the device belongs to whoever is up. This is the one line an
+  // online room replaces.
+  const youSlot = game.turn;
+  const interactive = !game.finished;
+
+  const you = playerFor(players, youSlot);
+
+  // The mover kept the turn because they closed a box — worth saying out loud,
+  // since "why is it still my turn?" is the rule newcomers trip over.
+  const extraTurn =
+    !game.finished &&
+    (game.lastMove?.claimed.length ?? 0) > 0 &&
+    game.lastMove.slot === game.turn;
+
+  const onDraw = useCallback(
+    (edge) => dispatch(drawEdge(edge, youSlot)),
+    [dispatch, youSlot]
+  );
+
+  const onPlayAgain = useCallback(() => dispatch(newGame()), [dispatch]);
+
+  const onSetupChange = useCallback(
+    (options) => dispatch(newGame(options)),
+    [dispatch]
+  );
+
+  return (
+    <Container>
+      <Toolbar
+        boxes={result.boxes}
+        claimed={result.claimed}
+        onRestart={onPlayAgain}
+        onToggleSetup={() => dispatch(setSetupOpen(!setupOpen))}
+        setupOpen={setupOpen}
+      />
+
+      <Stack>
+        {setupOpen && (
+          <Setup
+            onChange={onSetupChange}
+            playerCount={playerCount}
+            size={size}
+          />
+        )}
+
+        <TurnBanner
+          extraTurn={extraTurn}
+          finished={game.finished}
+          player={you}
+        />
+
+        <Scoreboard game={game} players={players} />
+
+        <Board
+          game={game}
+          interactive={interactive}
+          onDraw={onDraw}
+          overlay={
+            // The seam for #95: the count-up animation replaces the body of
+            // `Endgame` and mounts in exactly this slot, sized to the board.
+            result.finished ? (
+              <Endgame
+                game={game}
+                onPlayAgain={onPlayAgain}
+                players={players}
+                result={result}
+              />
+            ) : null
+          }
+          players={players}
+          youSlot={youSlot}
+        />
+      </Stack>
+
+      <Announcer game={game} players={players} result={result} />
+    </Container>
+  );
+}

--- a/src/app/(pages)/games/edge-case/Toolbar.jsx
+++ b/src/app/(pages)/games/edge-case/Toolbar.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  display: flex;
+  flex-flow: row nowrap;
+  font-size: 1rem;
+  gap: 0.5rem;
+  left: 0;
+  line-height: 1rem;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  @media (max-width: 600px) {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+  }
+`;
+
+// The game's name is the longest thing here and the page title already says it,
+// so it is the first thing to go when the toolbar runs out of room.
+const Name = styled.div`
+  flex: 1 1 auto;
+  white-space: nowrap;
+
+  @media (max-width: 480px) {
+    display: none;
+  }
+`;
+
+const Progress = styled.div`
+  color: var(--absentForeground);
+  flex: 1 1 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+`;
+
+const Action = styled.button`
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  color: var(--component);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: inherit;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
+  white-space: nowrap;
+
+  &[aria-pressed="true"] {
+    border-color: var(--component);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+export const Toolbar = ({ claimed, boxes, onRestart, onToggleSetup, setupOpen }) => (
+  <Container>
+    <Name>Edge Case</Name>
+    <Progress>
+      {claimed} / {boxes} boxes
+    </Progress>
+    <Action
+      aria-expanded={setupOpen}
+      aria-pressed={setupOpen}
+      onClick={onToggleSetup}
+      type="button"
+    >
+      {/* The Font Awesome kit replaces these <i>s with <svg>s after mount, so
+          each one lives in a wrapper React owns — otherwise unmounting the
+          button React no longer recognises throws. */}
+      <span>
+        <i className="fa-solid fa-sliders" />
+      </span>{" "}
+      Setup
+    </Action>
+    <Action onClick={onRestart} type="button">
+      <span>
+        <i className="fa-solid fa-rotate-left" />
+      </span>{" "}
+      Restart
+    </Action>
+  </Container>
+);

--- a/src/app/(pages)/games/edge-case/board/Board.jsx
+++ b/src/app/(pages)/games/edge-case/board/Board.jsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import styled from "@emotion/styled";
+import { range } from "lodash";
+
+import {
+  edgeKey,
+  horizontalEdgeCount,
+  Orientation,
+  verticalEdgeCount,
+} from "../_lib";
+import { playerFor } from "../players";
+import { useEdgeNavigation, useZoomPan } from "../hooks";
+import { Box } from "./Box";
+import { Edge } from "./Edge";
+import { ZoomControls } from "./ZoomControls";
+import {
+  describeBox,
+  describeEdge,
+  dotX,
+  dotY,
+  DOT_RADIUS,
+  viewBox,
+} from "./geometry";
+
+const Frame = styled.div`
+  width: 100%;
+`;
+
+// Wraps the board and nothing else, so anything handed in as `overlay` covers
+// exactly the board — not the zoom controls under it.
+const Surface = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Viewport = styled.div`
+  aspect-ratio: 1 / 1;
+  background-color: var(--absentBackground);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  position: relative;
+  /* The board owns every gesture that lands on it — the browser must not steal
+     a pinch to zoom the document or a drag to scroll the page. */
+  touch-action: none;
+  width: 100%;
+
+  &.zoomed {
+    cursor: grab;
+  }
+
+  &.panning {
+    cursor: grabbing;
+  }
+`;
+
+// The element the zoom/pan transform is applied to. Transforming here rather
+// than rewriting the viewBox means the browser keeps mapping pointer
+// coordinates for us, so hit targets survive zooming untouched.
+const Stage = styled.div`
+  height: 100%;
+  transform-origin: 0 0;
+  width: 100%;
+
+  > svg {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+`;
+
+/**
+ * The Edge Case board.
+ *
+ * This component owns NO game state. It is handed a state, a cast of players,
+ * which slot this device is playing, and whether that slot may move right now;
+ * it hands back the edge that was chosen. Everything it keeps to itself is
+ * presentation — what the cursor is over, what has focus, how far it is zoomed
+ * in.
+ *
+ * That split is deliberate and load-bearing: the local hotseat game passes
+ * `youSlot = game.turn`, and a networked room (#94) passes the slot that
+ * device joined as and drives `onDraw` over the wire. Neither needs the board
+ * to change.
+ *
+ * SVG rather than DOM elements, because the board is one coordinate system with
+ * three overlapping layers of geometry — box fills, thin lines, and tap targets
+ * five times their width — and only SVG lets those be sized independently of
+ * each other while scaling as one under zoom.
+ *
+ * @param {Object} props
+ * @param {Object} props.game - An engine state (see `_lib`)
+ * @param {Object[]} props.players - Player descriptors in join order
+ * @param {String|Number} [props.youSlot] - The slot this device plays, if any
+ * @param {Boolean} props.interactive - Whether this device may move right now
+ * @param {Function} props.onDraw - `({ orientation, index }) => void`
+ * @param {React.ReactNode} [props.overlay] - Rendered over the board, sized to
+ *   it. The endgame animation (#95) mounts here; a "waiting for the host"
+ *   curtain (#94) would too.
+ */
+export const Board = ({
+  game,
+  interactive,
+  onDraw,
+  overlay,
+  players,
+  youSlot,
+}) => {
+  const { activeKey, onKeyDown, register } = useEdgeNavigation(game);
+  const {
+    canZoomIn,
+    canZoomOut,
+    panning,
+    reset,
+    transform,
+    viewportProps,
+    zoomIn,
+    zoomOut,
+  } = useZoomPan();
+
+  // Hover (mouse) and focus (keyboard) are the same idea — "the edge I am
+  // about to commit to" — so they feed one preview. Hover wins when both are
+  // live, because the hand is the thing that just moved.
+  const [hovered, setHovered] = useState(null);
+  const [focused, setFocused] = useState(null);
+
+  const onHover = useCallback(
+    (orientation, index) =>
+      setHovered(orientation === null ? null : edgeKey(orientation, index)),
+    []
+  );
+  const onFocus = useCallback(
+    (orientation, index) => setFocused(edgeKey(orientation, index)),
+    []
+  );
+  const onBlur = useCallback(() => setFocused(null), []);
+
+  const onActivate = useCallback(
+    (orientation, index) => onDraw({ orientation, index }),
+    [onDraw]
+  );
+
+  const you = useMemo(() => playerFor(players, youSlot), [players, youSlot]);
+  const previewKey = hovered ?? focused;
+
+  // The colour of the edge that closed the last box, so a player can find the
+  // move that just happened on a board full of identical grey lines.
+  const lastColor = game.lastMove
+    ? playerFor(players, game.lastMove.slot).color
+    : null;
+  const lastKey = game.lastMove
+    ? edgeKey(game.lastMove.type, game.lastMove.index)
+    : null;
+
+  const claimedNow = useMemo(
+    () => new Set(game.lastMove?.claimed ?? []),
+    [game.lastMove]
+  );
+
+  const renderEdges = (orientation, count) =>
+    range(count).map((index) => {
+      const key = edgeKey(orientation, index);
+      const drawn = game.edges[orientation][index];
+      const open = interactive && !drawn;
+      const where = describeEdge(game, orientation, index);
+
+      return (
+        <Edge
+          grid={game}
+          index={index}
+          interactive={interactive}
+          key={key}
+          label={`${where}, ${drawn ? "drawn" : "open"}${
+            open ? `. Claim for ${you.name}` : ""
+          }`}
+          lastColor={key === lastKey ? lastColor : null}
+          onActivate={onActivate}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          onHover={onHover}
+          onKeyDown={onKeyDown}
+          orientation={orientation}
+          previewColor={open && previewKey === key ? you.color : null}
+          register={register(key)}
+          tabIndex={activeKey === key ? 0 : -1}
+        />
+      );
+    });
+
+  return (
+    <Frame>
+      <Surface>
+      <Viewport
+        {...viewportProps}
+        className={[transform.scale > 1 && "zoomed", panning && "panning"]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        <Stage
+          style={{
+            transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+          }}
+        >
+          <svg
+            aria-label={`Edge Case board, ${game.cols} by ${game.rows} boxes. Use the arrow keys to move between edges and enter to claim one.`}
+            role="group"
+            viewBox={viewBox(game)}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            {/* Bottom layer: who owns what. */}
+            <g>
+              {game.owners.map((slot, index) =>
+                slot === null ? null : (
+                  <Box
+                    fresh={claimedNow.has(index)}
+                    grid={game}
+                    index={index}
+                    key={index}
+                    label={`${describeBox(game, index)}, claimed by ${
+                      playerFor(players, slot).name
+                    }`}
+                    player={playerFor(players, slot)}
+                  />
+                )
+              )}
+            </g>
+
+            {/* Middle layer: the lines, and the targets over them. */}
+            <g>
+              {renderEdges(Orientation.Horizontal, horizontalEdgeCount(game))}
+              {renderEdges(Orientation.Vertical, verticalEdgeCount(game))}
+            </g>
+
+            {/* Top layer: the dots. Decorative, and never in the way of a tap. */}
+            <g fill="var(--absentForeground)" pointerEvents="none">
+              {range(game.rows + 1).map((row) =>
+                range(game.cols + 1).map((col) => (
+                  <circle
+                    cx={dotX(col)}
+                    cy={dotY(row)}
+                    key={`${row}-${col}`}
+                    r={DOT_RADIUS}
+                  />
+                ))
+              )}
+            </g>
+          </svg>
+        </Stage>
+      </Viewport>
+        {overlay}
+      </Surface>
+
+      <ZoomControls
+        canZoomIn={canZoomIn}
+        canZoomOut={canZoomOut}
+        onReset={reset}
+        onZoomIn={zoomIn}
+        onZoomOut={zoomOut}
+        scale={transform.scale}
+      />
+    </Frame>
+  );
+};

--- a/src/app/(pages)/games/edge-case/board/Box.jsx
+++ b/src/app/(pages)/games/edge-case/board/Box.jsx
@@ -1,0 +1,65 @@
+import { memo } from "react";
+import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+
+import { boxGeometry, CELL } from "./geometry";
+
+const claim = keyframes`
+  from { opacity: 0; transform: scale(0.55); }
+  to   { opacity: 1; transform: scale(1); }
+`;
+
+const Group = styled.g`
+  /* Boxes are scenery — every pointer that lands on one is aimed at an edge. */
+  pointer-events: none;
+
+  &.fresh {
+    animation: ${claim} 220ms ease-out both;
+    transform-box: fill-box;
+    transform-origin: center;
+  }
+
+  .initial {
+    dominant-baseline: central;
+    font-size: ${CELL * 0.44}px;
+    font-weight: 700;
+    text-anchor: middle;
+    user-select: none;
+  }
+`;
+
+/**
+ * A claimed box: the owner's colour, and the owner's initial.
+ *
+ * The initial is not decoration. Blue/purple and orange/green are the pairs
+ * people confuse, and a board that answers "whose is that?" in colour alone is
+ * unreadable for a good number of players. The letter is the redundant channel
+ * that makes the colour safe.
+ *
+ * The fill is deliberately translucent and the letter full strength: a solid
+ * block of any of the four palette colours drowns out the edges crossing it,
+ * and the contrast a letter needs is easier to win against the page background.
+ */
+export const Box = memo(function Box({ fresh, grid, index, label, player }) {
+  const { x, y, width, height, cx, cy } = boxGeometry(grid, index);
+
+  return (
+    <Group
+      aria-label={label}
+      className={fresh ? "fresh" : undefined}
+      role="img"
+    >
+      <rect
+        fill={player.color}
+        height={height}
+        opacity="0.28"
+        width={width}
+        x={x}
+        y={y}
+      />
+      <text aria-hidden="true" className="initial" fill={player.color} x={cx} y={cy}>
+        {player.initial}
+      </text>
+    </Group>
+  );
+});

--- a/src/app/(pages)/games/edge-case/board/Edge.jsx
+++ b/src/app/(pages)/games/edge-case/board/Edge.jsx
@@ -1,0 +1,153 @@
+import { memo, useCallback } from "react";
+import styled from "@emotion/styled";
+
+import { edgeGeometry, EDGE_STROKE, GHOST_STROKE } from "./geometry";
+
+const Group = styled.g`
+  outline: none;
+
+  /* The line the player actually sees. Thin, so the board reads as a lattice
+     of dots rather than a slab of colour. The thing you can hit is the
+     invisible rect below it, several times this wide. */
+  .line {
+    stroke-linecap: round;
+    transition: stroke 120ms ease-out, stroke-width 120ms ease-out,
+      opacity 120ms ease-out;
+  }
+
+  .hit {
+    fill: transparent;
+  }
+
+  &.open .hit {
+    cursor: pointer;
+  }
+
+  /* The focus ring doubles as the only view of how big the tap target really
+     is. Gated on :focus-visible rather than plain focus, because clicking an
+     edge focuses it too and a dashed box left behind every mouse click is
+     noise. Keyboard focus still previews the move in colour — that is driven by
+     React state, not this rule. */
+  .ring {
+    fill: none;
+    opacity: 0;
+    stroke: var(--var);
+    stroke-dasharray: 6 5;
+    stroke-width: 3;
+  }
+
+  &:focus-visible .ring {
+    opacity: 1;
+  }
+`;
+
+/**
+ * One edge: a faint hint of a line, the line itself once drawn, and a tap
+ * target far larger than either.
+ *
+ * Purely presentational — it is told what it looks like and who to call. It
+ * never reads game state, so the same component serves a local game, a
+ * networked one and a spectator view.
+ */
+export const Edge = memo(function Edge({
+  grid,
+  index,
+  interactive,
+  label,
+  lastColor,
+  onActivate,
+  onBlur,
+  onFocus,
+  onHover,
+  onKeyDown,
+  orientation,
+  previewColor,
+  register,
+  tabIndex,
+}) {
+  const { x1, y1, x2, y2, hit } = edgeGeometry(grid, orientation, index);
+  const drawn = grid.edges[orientation][index];
+  const open = interactive && !drawn;
+
+  const handleClick = useCallback(() => {
+    if (open) onActivate(orientation, index);
+  }, [index, onActivate, open, orientation]);
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        // Space scrolls the page by default, and the board is the page.
+        event.preventDefault();
+        if (open) onActivate(orientation, index);
+        return;
+      }
+
+      onKeyDown(event, orientation, index);
+    },
+    [index, onActivate, onKeyDown, open, orientation]
+  );
+
+  // Touch fires pointerenter on tap, which would leave a stale preview stuck
+  // under a finger that has already gone. Hover is a mouse idea; keep it there.
+  const handleEnter = useCallback(
+    (event) => {
+      if (event.pointerType === "mouse") onHover(orientation, index);
+    },
+    [index, onHover, orientation]
+  );
+
+  const handleLeave = useCallback(
+    (event) => {
+      if (event.pointerType === "mouse") onHover(null, null);
+    },
+    [onHover]
+  );
+
+  let stroke = "var(--absentForeground)";
+  let width = GHOST_STROKE;
+  let opacity = 0.35;
+
+  if (drawn) {
+    // Drawn edges are neutral by design: the engine records who closed a BOX,
+    // not who drew an edge, and inventing an owner here would put a colour on
+    // the board that no rule backs up. The one exception is the move that just
+    // happened, which is worth being able to find.
+    stroke = lastColor ?? "var(--foreground)";
+    width = lastColor ? EDGE_STROKE + 3 : EDGE_STROKE;
+    opacity = 1;
+  } else if (previewColor) {
+    stroke = previewColor;
+    width = EDGE_STROKE;
+    opacity = 0.6;
+  }
+
+  return (
+    <Group
+      aria-disabled={!open}
+      aria-label={label}
+      className={open ? "open" : undefined}
+      onBlur={onBlur}
+      onClick={handleClick}
+      onFocus={() => onFocus(orientation, index)}
+      onKeyDown={handleKeyDown}
+      onPointerEnter={handleEnter}
+      onPointerLeave={handleLeave}
+      ref={register}
+      role="button"
+      tabIndex={tabIndex}
+    >
+      <line
+        className="line"
+        opacity={opacity}
+        stroke={stroke}
+        strokeWidth={width}
+        x1={x1}
+        x2={x2}
+        y1={y1}
+        y2={y2}
+      />
+      <rect className="ring" rx="8" {...hit} />
+      <rect className="hit" {...hit} />
+    </Group>
+  );
+});

--- a/src/app/(pages)/games/edge-case/board/ZoomControls.jsx
+++ b/src/app/(pages)/games/edge-case/board/ZoomControls.jsx
@@ -1,0 +1,95 @@
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.4rem;
+  justify-content: flex-end;
+  padding-top: 0.5rem;
+`;
+
+const Readout = styled.span`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  margin-right: auto;
+`;
+
+const Button = styled.button`
+  align-items: center;
+  background-color: var(--selectionBackground);
+  border: none;
+  border-radius: 0.4rem;
+  color: var(--foreground);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.85rem;
+  height: 2.25rem;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0 0.6rem;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.35;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * Zoom by button as well as by gesture.
+ *
+ * Pinch and scroll cover the two common cases, but neither is reachable from a
+ * keyboard and neither exists on a trackpad-less desktop with a wheel-less
+ * mouse. These are the fallback, and they double as the only obvious signal
+ * that the board zooms at all.
+ */
+export const ZoomControls = ({
+  canZoomIn,
+  canZoomOut,
+  onReset,
+  onZoomIn,
+  onZoomOut,
+  scale,
+}) => (
+  <Container>
+    <Readout aria-hidden="true">
+      {scale > 1 ? `${scale.toFixed(1)}x — drag to pan` : "pinch or scroll to zoom"}
+    </Readout>
+    <Button
+      aria-label="Zoom out"
+      disabled={!canZoomOut}
+      onClick={onZoomOut}
+      type="button"
+    >
+      {/* Wrapped because the Font Awesome kit swaps the <i> for an <svg> after
+          mount, and React must own the node it later unmounts. */}
+      <span>
+        <i className="fa-solid fa-minus" />
+      </span>
+    </Button>
+    <Button
+      aria-label="Reset zoom"
+      disabled={!canZoomOut}
+      onClick={onReset}
+      type="button"
+    >
+      Fit
+    </Button>
+    <Button
+      aria-label="Zoom in"
+      disabled={!canZoomIn}
+      onClick={onZoomIn}
+      type="button"
+    >
+      <span>
+        <i className="fa-solid fa-plus" />
+      </span>
+    </Button>
+  </Container>
+);

--- a/src/app/(pages)/games/edge-case/board/geometry.js
+++ b/src/app/(pages)/games/edge-case/board/geometry.js
@@ -1,0 +1,185 @@
+/**
+ * Edge Case — turning engine coordinates into SVG coordinates.
+ *
+ * The engine's convention (dots, edges, boxes; see `_lib/edges.js`) is the only
+ * source of truth for WHICH edge is which. This file is the only source of
+ * truth for WHERE it is drawn. Nothing here knows a rule.
+ *
+ * Board units, not pixels: the SVG carries a `viewBox` and is stretched to
+ * whatever the layout gives it, so one box is always exactly `CELL` units and
+ * every size of board renders from the same numbers.
+ */
+
+import { boxCoords, edgeCoords, edgeIndex, Orientation } from "../_lib";
+
+const { Horizontal } = Orientation;
+
+/** One box, in board units. Everything else is a fraction of this. */
+export const CELL = 100;
+
+/** Breathing room around the rim so outer dots and strokes are not clipped. */
+export const PADDING = 34;
+
+export const DOT_RADIUS = 8;
+
+/** The drawn edge, and the faint hint of one that is still up for grabs. */
+export const EDGE_STROKE = 13;
+export const GHOST_STROKE = 4;
+
+/**
+ * The invisible tap target over each edge — 50 x 50 units, a full quarter of a
+ * box, against a 13-unit line. This is the whole ball game on a phone: a 2px
+ * line is untappable, and the fix is a hit area far larger than the thing it
+ * hits.
+ *
+ * 50 is not arbitrary. A hit rect is inset from its dots by `HIT / 2`, which is
+ * exactly the point at which a horizontal target and the vertical target
+ * sharing its dot stop overlapping — so no tap is ever ambiguous — and 50 is
+ * the value that makes the resulting rect as large as it can be. Bigger in one
+ * direction only shrinks it in the other.
+ */
+export const HIT = 50;
+const INSET = HIT / 2;
+
+/** The viewBox a board of this many boxes needs. */
+export const viewBox = ({ cols, rows }) =>
+  `0 0 ${cols * CELL + PADDING * 2} ${rows * CELL + PADDING * 2}`;
+
+/** Dot (row, col) → SVG centre. */
+export const dotX = (col) => PADDING + col * CELL;
+export const dotY = (row) => PADDING + row * CELL;
+
+/**
+ * Everything needed to draw and hit-test one edge.
+ *
+ * @param {Object} grid - Anything with `cols` and `rows` (a game state will do)
+ * @param {String} orientation - "h" or "v"
+ * @param {Number} index - Index into `state.edges[orientation]`
+ * @returns {Object} Line endpoints, the hit rect, and the dot it starts at
+ */
+export const edgeGeometry = (grid, orientation, index) => {
+  const { row, col } = edgeCoords(grid, orientation, index);
+  const x = dotX(col);
+  const y = dotY(row);
+
+  if (orientation === Horizontal) {
+    return {
+      row,
+      col,
+      x1: x,
+      y1: y,
+      x2: x + CELL,
+      y2: y,
+      hit: { x: x + INSET, y: y - HIT / 2, width: CELL - HIT, height: HIT },
+    };
+  }
+
+  return {
+    row,
+    col,
+    x1: x,
+    y1: y,
+    x2: x,
+    y2: y + CELL,
+    hit: { x: x - HIT / 2, y: y + INSET, width: HIT, height: CELL - HIT },
+  };
+};
+
+/**
+ * The rect a box fills.
+ * @param {Object} grid - Anything with `cols` and `rows`
+ * @param {Number} index - Box index, row-major
+ * @returns {Object} `{ row, col, x, y, width, height, cx, cy }`
+ */
+export const boxGeometry = (grid, index) => {
+  const { row, col } = boxCoords(grid, index);
+  const x = dotX(col);
+  const y = dotY(row);
+
+  return {
+    row,
+    col,
+    x,
+    y,
+    width: CELL,
+    height: CELL,
+    cx: x + CELL / 2,
+    cy: y + CELL / 2,
+  };
+};
+
+/**
+ * The edge an arrow key should move focus to.
+ *
+ * Edges do not sit on a grid of their own — horizontals and verticals
+ * interleave — so "up" from a horizontal edge is a vertical one. The rule is
+ * simply "the nearest edge whose centre lies that way", resolved to the
+ * upper/left candidate when two are equally near, which keeps the walk
+ * predictable.
+ *
+ * @param {Object} grid - Anything with `cols` and `rows`
+ * @param {String} orientation - "h" or "v"
+ * @param {Number} index - Index into `state.edges[orientation]`
+ * @param {String} key - An `event.key`: ArrowUp/Down/Left/Right
+ * @returns {?Object} An edge id, or null when there is nothing that way
+ */
+export const neighborEdge = (grid, orientation, index, key) => {
+  const { cols, rows } = grid;
+  const { row, col } = edgeCoords(grid, orientation, index);
+  // Both return an edge id — `{ orientation, index }` — or null when the
+  // coordinates fall off the board.
+  const h = (r, c) =>
+    r >= 0 && r <= rows && c >= 0 && c < cols
+      ? { orientation: Orientation.Horizontal, index: edgeIndex(grid, Orientation.Horizontal, r, c) }
+      : null;
+  const v = (r, c) =>
+    r >= 0 && r < rows && c >= 0 && c <= cols
+      ? { orientation: Orientation.Vertical, index: edgeIndex(grid, Orientation.Vertical, r, c) }
+      : null;
+
+  if (orientation === Horizontal) {
+    // A horizontal edge spans dots (row, col) → (row, col + 1).
+    switch (key) {
+      case "ArrowLeft":
+        return h(row, col - 1);
+      case "ArrowRight":
+        return h(row, col + 1);
+      case "ArrowUp":
+        return v(row - 1, col);
+      case "ArrowDown":
+        return v(row, col);
+      default:
+        return null;
+    }
+  }
+
+  // A vertical edge spans dots (row, col) → (row + 1, col).
+  switch (key) {
+    case "ArrowUp":
+      return v(row - 1, col);
+    case "ArrowDown":
+      return v(row + 1, col);
+    case "ArrowLeft":
+      return h(row, col - 1);
+    case "ArrowRight":
+      return h(row, col);
+    default:
+      return null;
+  }
+};
+
+/** Human-readable position of an edge, for screen readers. */
+export const describeEdge = (grid, orientation, index) => {
+  const { row, col } = edgeCoords(grid, orientation, index);
+
+  return orientation === Horizontal
+    ? `horizontal edge, row ${row + 1}, column ${col + 1}`
+    : `vertical edge, row ${row + 1}, column ${col + 1}`;
+};
+
+/** Human-readable position of a box, for screen readers. */
+export const describeBox = (grid, index) => {
+  const { row, col } = boxCoords(grid, index);
+
+  return `box row ${row + 1}, column ${col + 1}`;
+};

--- a/src/app/(pages)/games/edge-case/board/index.js
+++ b/src/app/(pages)/games/edge-case/board/index.js
@@ -1,0 +1,2 @@
+export * from "./Board";
+export * from "./geometry";

--- a/src/app/(pages)/games/edge-case/components/Announcer.jsx
+++ b/src/app/(pages)/games/edge-case/components/Announcer.jsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+
+import { boxCoords } from "../_lib";
+import { playerFor } from "../players";
+import { VisuallyHidden } from "./VisuallyHidden";
+
+const list = (items) =>
+  items.length < 2
+    ? items.join("")
+    : `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+
+/**
+ * The running commentary a screen reader hears.
+ *
+ * The board is a wall of SVG: a player who cannot see it needs the two facts a
+ * sighted player reads off it instantly — what just happened, and who is up.
+ * Claimed boxes are named here as well as labelled on the board itself, because
+ * "who owns that square" is the question the whole game turns on, and hunting
+ * for it in the graphic is not an answer.
+ */
+export const Announcer = ({ game, players, result }) => {
+  const message = useMemo(() => {
+    const upNext = playerFor(players, game.turn);
+
+    if (!game.lastMove) {
+      return `New game, ${game.cols} by ${game.rows} boxes. ${upNext.name} to move.`;
+    }
+
+    const { claimed, slot, type } = game.lastMove;
+    const mover = playerFor(players, slot);
+    const orientation = type === "h" ? "horizontal" : "vertical";
+
+    const boxes = claimed.map((index) => {
+      const { row, col } = boxCoords(game, index);
+      return `row ${row + 1} column ${col + 1}`;
+    });
+
+    let sentence = `${mover.name} drew a ${orientation} edge.`;
+
+    if (claimed.length > 0) {
+      sentence += ` ${mover.name} claimed ${claimed.length} ${
+        claimed.length === 1 ? "box" : "boxes"
+      }: ${list(boxes)}.`;
+    }
+
+    if (result.finished) {
+      sentence += result.tie
+        ? ` Game over. Tied at ${result.standings[0].score}.`
+        : ` Game over. ${playerFor(players, result.winner).name} wins ${
+            result.standings[0].score
+          } to ${result.standings[1].score}.`;
+      return sentence;
+    }
+
+    sentence +=
+      claimed.length > 0
+        ? ` ${mover.name} goes again.`
+        : ` ${upNext.name} to move.`;
+
+    return sentence;
+  }, [game, players, result]);
+
+  return (
+    <VisuallyHidden aria-atomic="true" aria-live="polite" role="status">
+      {message}
+    </VisuallyHidden>
+  );
+};

--- a/src/app/(pages)/games/edge-case/components/Endgame.jsx
+++ b/src/app/(pages)/games/edge-case/components/Endgame.jsx
@@ -1,0 +1,158 @@
+import styled from "@emotion/styled";
+
+import { playerFor } from "../players";
+
+const Overlay = styled.div`
+  align-items: center;
+  /* Translucent, not opaque: the finished board is the result, and covering it
+     up to announce the result would be a strange thing to do. */
+  background-color: rgba(31, 31, 31, 0.82);
+  border-radius: 0.75rem;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 1rem;
+  inset: 0;
+  justify-content: center;
+  padding: 1.5rem;
+  position: absolute;
+  text-align: center;
+`;
+
+const Headline = styled.h2`
+  font-size: 1.5rem;
+  line-height: 1.9rem;
+  margin: 0;
+
+  .slot {
+    color: var(--slot);
+  }
+`;
+
+const Standings = styled.ol`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.35rem;
+  list-style: none;
+  margin: 0;
+  max-width: 18rem;
+  padding: 0;
+  width: 100%;
+`;
+
+const Row = styled.li`
+  align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.5rem;
+
+  .chip {
+    align-items: center;
+    background-color: var(--slot);
+    border-radius: 0.35rem;
+    color: var(--background);
+    display: inline-flex;
+    font-size: 0.85rem;
+    font-weight: 700;
+    height: 1.5rem;
+    justify-content: center;
+    width: 1.5rem;
+  }
+
+  .name {
+    color: var(--slot);
+    flex: 1 1 auto;
+    text-align: left;
+  }
+
+  .score {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+  }
+`;
+
+const Again = styled.button`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--component);
+  border-radius: 0.4rem;
+  color: var(--component);
+  cursor: pointer;
+  font-size: 1rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 1.25rem;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * The end of the game.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * SEAM FOR #95 — the count-up animation.
+ *
+ * This is the mount point, and the props below are the whole contract:
+ *
+ *   game        the finished engine state
+ *   players     player descriptors in join order — { slot, name, initial, color }
+ *   result      `getResult(game)`: { standings, leaders, winner, tie, boxes,
+ *               claimed, finished }. `standings` is already sorted and ranked.
+ *   onPlayAgain () => void — dispatches a fresh game with the same settings
+ *
+ * `Game` renders this inside the board frame, absolutely positioned over the
+ * board, and only when `result.finished` is true. What is below is a plain
+ * static result: replace the body, keep the props.
+ *
+ * Two things to know before animating: `result.tie` is TRUE on a live 0–0 game,
+ * so it only means anything once `finished`; and the engine deliberately leaves
+ * `game.turn` on the final mover, so there is always a valid slot and colour on
+ * screen.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+export const Endgame = ({ game, onPlayAgain, players, result }) => {
+  const { standings, leaders, tie, winner } = result;
+  const champion = playerFor(players, winner ?? leaders[0]);
+
+  return (
+    <Overlay>
+      <Headline style={{ "--slot": champion.color }}>
+        {tie ? (
+          <>
+            Tied at {standings[0].score} —{" "}
+            {leaders
+              .map((slot) => playerFor(players, slot).name)
+              .join(" and ")}
+          </>
+        ) : (
+          <>
+            <span className="slot">{champion.name}</span> wins
+          </>
+        )}
+      </Headline>
+
+      <Standings>
+        {standings.map(({ slot, score }) => {
+          const player = playerFor(players, slot);
+
+          return (
+            <Row key={slot} style={{ "--slot": player.color }}>
+              <span aria-hidden="true" className="chip">
+                {player.initial}
+              </span>
+              <span className="name">{player.name}</span>
+              <span className="score">
+                {score}
+                <span aria-hidden="true"> / {game.owners.length}</span>
+              </span>
+            </Row>
+          );
+        })}
+      </Standings>
+
+      <Again autoFocus onClick={onPlayAgain} type="button">
+        Play again
+      </Again>
+    </Overlay>
+  );
+};

--- a/src/app/(pages)/games/edge-case/components/Scoreboard.jsx
+++ b/src/app/(pages)/games/edge-case/components/Scoreboard.jsx
@@ -1,0 +1,109 @@
+import styled from "@emotion/styled";
+
+import { VisuallyHidden } from "./VisuallyHidden";
+
+const List = styled.ul`
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  /* Two columns suits two players and four (as a 2x2) at every width — four
+     across a phone-width column truncates every name to "Pur…". Three is the
+     odd one out: it gets its own row once there is width for it, rather than
+     leaving an orphan on a second line. */
+  &.three {
+    @media (min-width: 480px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+`;
+
+const Player = styled.li`
+  align-items: center;
+  background-color: var(--absentBackground);
+  border-radius: 0.6rem;
+  /* A transparent border, not none: the active player gains a coloured one and
+     nothing may shift when they do. */
+  border: 2px solid transparent;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.5rem 0.65rem;
+
+  &.active {
+    background-color: var(--selectionBackground);
+    border-color: var(--slot);
+  }
+`;
+
+// Colour plus letter, everywhere a player is named — the same pairing the board
+// stamps on a claimed box, so the two are matched at a glance.
+const Chip = styled.span`
+  align-items: center;
+  background-color: var(--slot);
+  border-radius: 0.35rem;
+  color: var(--background);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 0.9rem;
+  font-weight: 700;
+  height: 1.6rem;
+  justify-content: center;
+  width: 1.6rem;
+`;
+
+const Name = styled.span`
+  color: var(--slot);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Score = styled.span`
+  color: var(--foreground);
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+`;
+
+/**
+ * Live score, one row per player, in join order.
+ *
+ * Join order rather than rank: the running order is information too — it is how
+ * a player works out who moves after them — and a list that reshuffles itself
+ * mid-game is a list nobody can read.
+ */
+export const Scoreboard = ({ game, players }) => (
+  <List aria-label="Scores" className={players.length === 3 ? "three" : undefined}>
+    {players.map((player) => {
+      const active = game.turn === player.slot;
+      const score = game.scores[player.slot] ?? 0;
+
+      return (
+        <Player
+          className={active ? "active" : undefined}
+          key={player.slot}
+          style={{ "--slot": player.color }}
+        >
+          <Chip aria-hidden="true">{player.initial}</Chip>
+          <Name>
+            {player.name}
+            {active && <VisuallyHidden>, to move</VisuallyHidden>}
+          </Name>
+          <Score>
+            {score}
+            <VisuallyHidden> {score === 1 ? "box" : "boxes"}</VisuallyHidden>
+          </Score>
+        </Player>
+      );
+    })}
+  </List>
+);

--- a/src/app/(pages)/games/edge-case/components/Setup.jsx
+++ b/src/app/(pages)/games/edge-case/components/Setup.jsx
@@ -1,0 +1,128 @@
+import styled from "@emotion/styled";
+import { range } from "lodash";
+
+import { GRID_SIZES, MAX_PLAYERS, MIN_PLAYERS } from "../_lib";
+import { PLAYER_PALETTE } from "../players";
+
+const Panel = styled.div`
+  background-color: var(--absentBackground);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.85rem;
+  padding: 0.9rem;
+  width: 100%;
+`;
+
+const Field = styled.fieldset`
+  align-items: center;
+  border: none;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+`;
+
+const Legend = styled.legend`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  padding: 0 0 0.35rem;
+`;
+
+const Choice = styled.button`
+  background-color: transparent;
+  border: 1px solid var(--absentForeground);
+  border-radius: 0.4rem;
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 0.9rem;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.7rem;
+
+  &[aria-pressed="true"] {
+    background-color: var(--selectionBackground);
+    border-color: var(--component);
+    color: var(--component);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+const Swatches = styled.span`
+  display: inline-flex;
+  gap: 0.2rem;
+  margin-left: 0.35rem;
+  vertical-align: middle;
+`;
+
+const Swatch = styled.span`
+  background-color: var(--slot);
+  border-radius: 0.15rem;
+  display: inline-block;
+  height: 0.6rem;
+  width: 0.6rem;
+`;
+
+const Warning = styled.p`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  margin: 0;
+`;
+
+/**
+ * Board size and player count for a game round one device.
+ *
+ * Both controls start a new game the moment they change, which is why the panel
+ * is behind a toggle rather than sitting over the board: it is a destructive
+ * control, and it should take a deliberate act to reach it.
+ *
+ * Sizes are quoted in dots, the unit the engine's `createState` takes and the
+ * unit a player counts when they look at the board. The box count comes along
+ * in brackets so the difference is never a surprise.
+ */
+export const Setup = ({ onChange, playerCount, size }) => (
+  <Panel>
+    <Field>
+      <Legend>Players</Legend>
+      {range(MIN_PLAYERS, MAX_PLAYERS + 1).map((count) => (
+        <Choice
+          aria-pressed={count === playerCount}
+          key={count}
+          onClick={() => onChange({ playerCount: count })}
+          type="button"
+        >
+          {count}
+          <Swatches aria-hidden="true">
+            {PLAYER_PALETTE.slice(0, count).map(({ color, colorName }) => (
+              <Swatch key={colorName} style={{ "--slot": color }} />
+            ))}
+          </Swatches>
+        </Choice>
+      ))}
+    </Field>
+
+    <Field>
+      <Legend>Board</Legend>
+      {GRID_SIZES.map((dots) => (
+        <Choice
+          aria-pressed={dots === size}
+          key={dots}
+          onClick={() => onChange({ size: dots })}
+          type="button"
+        >
+          {dots}&times;{dots} dots
+          <span aria-hidden="true">
+            {" "}
+            ({dots - 1}&times;{dots - 1})
+          </span>
+        </Choice>
+      ))}
+    </Field>
+
+    <Warning>Changing either starts a new game.</Warning>
+  </Panel>
+);

--- a/src/app/(pages)/games/edge-case/components/TurnBanner.jsx
+++ b/src/app/(pages)/games/edge-case/components/TurnBanner.jsx
@@ -1,0 +1,75 @@
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  /* The colour bar. Four rem of solid slot colour running the width of the
+     banner is the answer to "which one am I?" from across a table — a small
+     swatch next to a name is not. */
+  border-left: 0.4rem solid var(--slot);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0.6rem 0.9rem;
+  width: 100%;
+`;
+
+const Chip = styled.span`
+  align-items: center;
+  background-color: var(--slot);
+  border-radius: 0.4rem;
+  color: var(--background);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+  font-weight: 700;
+  height: 2.1rem;
+  justify-content: center;
+  width: 2.1rem;
+`;
+
+const Copy = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.15rem;
+  min-width: 0;
+`;
+
+const Headline = styled.div`
+  color: var(--slot);
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.4rem;
+`;
+
+const Hint = styled.small`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  line-height: 1.05rem;
+`;
+
+/**
+ * Whose turn it is, in their colour, at the size the question deserves.
+ *
+ * Rendered even after the game is over, because the engine leaves `turn` with
+ * the final mover on purpose — the board must never be left without a valid
+ * slot, and therefore never without a colour.
+ */
+export const TurnBanner = ({ hint, player, finished, extraTurn }) => (
+  <Container role="status" style={{ "--slot": player.color }}>
+    <Chip aria-hidden="true">{player.initial}</Chip>
+    <Copy>
+      <Headline>
+        {finished ? `${player.name} closed the last box` : `${player.name} to move`}
+      </Headline>
+      <Hint>
+        {hint ??
+          (extraTurn
+            ? "Box closed — go again."
+            : "Claim the edge. Close the case.")}
+      </Hint>
+    </Copy>
+  </Container>
+);

--- a/src/app/(pages)/games/edge-case/components/VisuallyHidden.js
+++ b/src/app/(pages)/games/edge-case/components/VisuallyHidden.js
@@ -1,0 +1,17 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+// Text for screen readers only. Clipped rather than `display: none`, which
+// would take it out of the accessibility tree along with everything else.
+export const VisuallyHidden = styled.span`
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`;

--- a/src/app/(pages)/games/edge-case/components/index.js
+++ b/src/app/(pages)/games/edge-case/components/index.js
@@ -1,0 +1,6 @@
+export * from "./Announcer";
+export * from "./Endgame";
+export * from "./Scoreboard";
+export * from "./Setup";
+export * from "./TurnBanner";
+export * from "./VisuallyHidden";

--- a/src/app/(pages)/games/edge-case/context/actions.js
+++ b/src/app/(pages)/games/edge-case/context/actions.js
@@ -1,0 +1,37 @@
+// The engine already names the move action, because it is the one the shared
+// realtime core will dispatch (#94). Reusing it means a local move and a
+// networked move are literally the same object.
+import { DRAW_EDGE } from "../_lib";
+
+export { DRAW_EDGE };
+
+export const NEW_GAME = "NEW GAME";
+export const SET_SETUP_OPEN = "SET SETUP OPEN";
+
+/**
+ * Claim an edge for a slot.
+ * @param {Object} edge - `{ orientation, index }`
+ * @param {String|Number} slot - The player making the move
+ */
+export const drawEdge = (edge, slot) => ({
+  type: DRAW_EDGE,
+  edge,
+  slot,
+});
+
+/**
+ * Start over. Anything left out is inherited from the game in progress, so
+ * "play again" and "switch to four players" are the same action.
+ * @param {Object} [options]
+ * @param {Number} [options.size] - Dots per side: 5, 7 or 9
+ * @param {Number} [options.playerCount] - 2 to 4
+ */
+export const newGame = (options = {}) => ({
+  type: NEW_GAME,
+  ...options,
+});
+
+export const setSetupOpen = (open) => ({
+  type: SET_SETUP_OPEN,
+  open,
+});

--- a/src/app/(pages)/games/edge-case/context/index.jsx
+++ b/src/app/(pages)/games/edge-case/context/index.jsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { createContext, useMemo, useReducer } from "react";
+
+import { DEFAULT_GRID_SIZE, MIN_PLAYERS } from "../_lib";
+import reducer from "./reducer";
+// Aliased: `newGame` is also the name of the action creator this module
+// re-exports, and they are different things — one builds a state, one asks for
+// one.
+import { newGame as freshGame } from "./reducer/newGame";
+
+// A two-player game on a seven-dot (six-by-six box) board: big enough that the
+// chain play the game is actually about shows up, small enough to finish.
+export const createDefaultState = () =>
+  freshGame({ size: DEFAULT_GRID_SIZE, playerCount: MIN_PLAYERS });
+
+export const Context = createContext({
+  state: createDefaultState(),
+  dispatch: () => {},
+});
+
+/**
+ * The local hotseat game — two to four players passing one device.
+ *
+ * This is the seam for #94: online play swaps this provider for one backed by a
+ * room, and everything below it keeps working, because nothing below it knows
+ * where the state came from. The contract is the value shape — `{ state:
+ * { game, players, ... }, dispatch }` — plus the two facts `Game` reads off it
+ * to drive the board: which slot this device plays, and whether it may move.
+ */
+export const ContextProvider = ({ children }) => {
+  // Lazily built, but from constants only — the page is prerendered, so the
+  // first client render has to produce exactly the markup the server did.
+  const [state, dispatch] = useReducer(reducer, undefined, createDefaultState);
+
+  const store = useMemo(() => ({ state, dispatch }), [state, dispatch]);
+
+  return <Context.Provider value={store}>{children}</Context.Provider>;
+};
+
+export * from "./actions";

--- a/src/app/(pages)/games/edge-case/context/reducer/drawEdge.js
+++ b/src/app/(pages)/games/edge-case/context/reducer/drawEdge.js
@@ -1,0 +1,26 @@
+import { drawEdge as applyMove } from "../../_lib";
+
+/**
+ * Hand a move to the engine and keep whatever comes back.
+ *
+ * Not one rule lives here. The engine decides whether the move is legal, who
+ * owns what, whether the mover goes again and whether the game is over — the
+ * same code the server and every other client will run, so a local game and a
+ * networked one can never drift apart.
+ *
+ * A rejected move comes back as the SAME state object by reference, which is
+ * the engine's contract; returning the unchanged wrapper on that path means
+ * React skips the render entirely.
+ *
+ * @param {Object} state - The local wrapper state
+ * @param {Object} edge - `{ orientation, index }`
+ * @param {String|Number} slot - The player making the move
+ * @returns {Object} The next wrapper state
+ */
+export const drawEdge = (state, edge, slot) => {
+  const { state: game } = applyMove(state.game, edge, slot);
+
+  if (game === state.game) return state;
+
+  return { ...state, game };
+};

--- a/src/app/(pages)/games/edge-case/context/reducer/index.js
+++ b/src/app/(pages)/games/edge-case/context/reducer/index.js
@@ -1,0 +1,41 @@
+import { DRAW_EDGE, NEW_GAME, SET_SETUP_OPEN } from "../actions";
+import { drawEdge } from "./drawEdge";
+import { newGame } from "./newGame";
+
+/**
+ * The local (hotseat) wrapper around the engine.
+ *
+ * The wrapper state is deliberately thin:
+ *
+ *   { game, players, size, playerCount, setupOpen }
+ *
+ * `game` is an engine state and nothing else writes to it. Everything beside it
+ * is presentation — who is what colour, what the size control is set to, whether
+ * the setup panel is open. A networked room (#94) replaces this file wholesale
+ * and keeps the same `game`/`players` shape, so the board and the scoreboard
+ * carry over untouched.
+ */
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case DRAW_EDGE:
+      return drawEdge(state, action.edge, action.slot);
+    case NEW_GAME:
+      // Anything the action leaves out is inherited, so "play again" is just a
+      // new game with no options at all. The setup panel stays as it was —
+      // picking a size and then a player count is one thought, and the panel
+      // slamming shut between them is not.
+      return {
+        ...newGame({
+          size: action.size ?? state.size,
+          playerCount: action.playerCount ?? state.playerCount,
+        }),
+        setupOpen: state.setupOpen,
+      };
+    case SET_SETUP_OPEN:
+      return { ...state, setupOpen: action.open };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/app/(pages)/games/edge-case/context/reducer/newGame.js
+++ b/src/app/(pages)/games/edge-case/context/reducer/newGame.js
@@ -1,0 +1,40 @@
+import {
+  createState,
+  DEFAULT_GRID_SIZE,
+  GRID_SIZES,
+  MAX_PLAYERS,
+  MIN_PLAYERS,
+} from "../../_lib";
+import { createPlayers, HOTSEAT_SLOTS } from "../../players";
+
+const clampPlayers = (count) =>
+  Math.min(MAX_PLAYERS, Math.max(MIN_PLAYERS, count));
+
+/**
+ * A fresh local game.
+ *
+ * `createState` throws on a bad size or player count rather than limping on
+ * with half a board, so the numbers are clamped to the legal range before they
+ * reach it — a stray value from a control should never take the page down.
+ *
+ * @param {Object} [options]
+ * @param {Number} [options.size] - Dots per side: 5, 7 or 9
+ * @param {Number} [options.playerCount] - 2 to 4
+ * @returns {Object} A local wrapper state
+ */
+export const newGame = ({ size, playerCount } = {}) => {
+  const dots = GRID_SIZES.includes(size) ? size : DEFAULT_GRID_SIZE;
+  const count = clampPlayers(playerCount ?? MIN_PLAYERS);
+  const slots = HOTSEAT_SLOTS.slice(0, count);
+
+  return {
+    // `size` counts DOTS per side. The engine state that comes back counts
+    // BOXES in `cols`/`rows` — five dots is a four-by-four board. Keeping the
+    // dot count here means the size control and the engine never disagree.
+    size: dots,
+    playerCount: count,
+    players: createPlayers(slots),
+    game: createState({ size: dots, slots }),
+    setupOpen: false,
+  };
+};

--- a/src/app/(pages)/games/edge-case/hooks/index.js
+++ b/src/app/(pages)/games/edge-case/hooks/index.js
@@ -1,0 +1,2 @@
+export * from "./useEdgeNavigation";
+export * from "./useZoomPan";

--- a/src/app/(pages)/games/edge-case/hooks/useEdgeNavigation.js
+++ b/src/app/(pages)/games/edge-case/hooks/useEdgeNavigation.js
@@ -1,0 +1,62 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { edgeKey, Orientation } from "../_lib";
+import { neighborEdge } from "../board/geometry";
+
+/**
+ * Keyboard access to the board.
+ *
+ * A 9-dot board has 144 edges. Putting all of them in the tab order would bury
+ * the rest of the page, so they share a single tab stop — a roving tabindex —
+ * and the arrow keys walk between them once focus is inside. That is the same
+ * bargain the tic-tac-overflow board strikes, scaled up.
+ *
+ * Every edge is reachable, drawn or not: a keyboard-only player has to be able
+ * to survey the board, not just the moves still open to them.
+ *
+ * @param {Object} grid - Anything with `cols` and `rows` (a game state will do)
+ * @returns {Object} The key that currently owns the tab stop, a ref registrar,
+ *   and the keydown handler to hang off every edge
+ */
+export const useEdgeNavigation = (grid) => {
+  // The top-left horizontal edge always exists on any legal board, so it is a
+  // safe place for the tab stop to start.
+  const [activeKey, setActiveKey] = useState(() =>
+    edgeKey(Orientation.Horizontal, 0)
+  );
+
+  const elements = useRef(new Map());
+
+  const register = useCallback(
+    (key) => (element) => {
+      if (element) elements.current.set(key, element);
+      else elements.current.delete(key);
+    },
+    []
+  );
+
+  const focusEdge = useCallback((orientation, index) => {
+    const key = edgeKey(orientation, index);
+    setActiveKey(key);
+    elements.current.get(key)?.focus();
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event, orientation, index) => {
+      if (!event.key.startsWith("Arrow")) return;
+
+      // Swallow arrows even at the rim, so the page never scrolls out from
+      // under a player steering the board.
+      event.preventDefault();
+
+      const next = neighborEdge(grid, orientation, index, event.key);
+      if (next) focusEdge(next.orientation, next.index);
+    },
+    [focusEdge, grid]
+  );
+
+  return useMemo(
+    () => ({ activeKey, focusEdge, onKeyDown, register }),
+    [activeKey, focusEdge, onKeyDown, register]
+  );
+};

--- a/src/app/(pages)/games/edge-case/hooks/useZoomPan.js
+++ b/src/app/(pages)/games/edge-case/hooks/useZoomPan.js
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Scale 1 is "the whole board fits" — there is never a reason to go below it,
+// because the board is always square and always sized to its frame.
+const MIN_SCALE = 1;
+const MAX_SCALE = 5;
+
+// How far a pointer may wander before a tap stops being a tap and becomes a
+// pan. Below this a shaky finger still places the edge it was aimed at.
+const DRAG_THRESHOLD = 8;
+
+const clamp = (value, low, high) => Math.min(high, Math.max(low, value));
+
+const distance = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+const midpoint = (a, b) => ({ x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 });
+
+/**
+ * Pinch/scroll zoom and drag pan for the board.
+ *
+ * The transform is applied as CSS on a wrapper element rather than baked into
+ * the SVG `viewBox`, which keeps hit-testing free: the browser maps pointer
+ * coordinates through the transform itself, so an edge stays exactly as
+ * clickable at 5x as it is at 1x, and focus rings scale with it.
+ *
+ * Panning and tapping share the same pointer, so a drag has to disqualify the
+ * click it would otherwise end with. That is what `DRAG_THRESHOLD` and the
+ * capture-phase click guard are for — without them, every pan drops an edge on
+ * the board where the finger came to rest.
+ *
+ * @returns {Object} A ref for the viewport, the current transform, the props to
+ *   spread onto the viewport, and the zoom controls
+ */
+export const useZoomPan = () => {
+  const viewportRef = useRef(null);
+  const [transform, setTransform] = useState({ scale: 1, x: 0, y: 0 });
+
+  // Live pointers, keyed by pointerId: one is a pan, two are a pinch.
+  const pointers = useRef(new Map());
+  const pinch = useRef(null);
+  // Where the gesture started, so a wobble can be told from a drag.
+  const origin = useRef(null);
+  // Set the moment a gesture passes the threshold; read (and cleared) by the
+  // click guard so the gesture cannot also place an edge.
+  const dragged = useRef(false);
+  const [panning, setPanning] = useState(false);
+
+  // Translation is clamped so the board can never be flung off its own frame:
+  // at scale s the content is s times the viewport, so the offset lives in
+  // [size * (1 - s), 0]. At scale 1 that collapses to 0 and re-centres itself.
+  const clampOffset = useCallback((x, y, scale) => {
+    const frame = viewportRef.current?.getBoundingClientRect();
+    const width = frame?.width ?? 0;
+    const height = frame?.height ?? 0;
+
+    return {
+      x: clamp(x, width * (1 - scale), 0),
+      y: clamp(y, height * (1 - scale), 0),
+    };
+  }, []);
+
+  /**
+   * Zoom by a factor about a focal point in viewport coordinates, so the board
+   * grows away from the finger (or the cursor) rather than from the corner.
+   */
+  const zoomBy = useCallback(
+    (factor, focus) => {
+      setTransform((current) => {
+        const scale = clamp(current.scale * factor, MIN_SCALE, MAX_SCALE);
+        if (scale === current.scale) return current;
+
+        const frame = viewportRef.current?.getBoundingClientRect();
+        const point = focus ?? {
+          x: (frame?.width ?? 0) / 2,
+          y: (frame?.height ?? 0) / 2,
+        };
+
+        const ratio = scale / current.scale;
+        const next = clampOffset(
+          point.x - (point.x - current.x) * ratio,
+          point.y - (point.y - current.y) * ratio,
+          scale
+        );
+
+        return { scale, ...next };
+      });
+    },
+    [clampOffset]
+  );
+
+  const panBy = useCallback(
+    (dx, dy) => {
+      setTransform((current) => ({
+        ...current,
+        ...clampOffset(current.x + dx, current.y + dy, current.scale),
+      }));
+    },
+    [clampOffset]
+  );
+
+  const zoomIn = useCallback(() => zoomBy(1.5), [zoomBy]);
+  const zoomOut = useCallback(() => zoomBy(1 / 1.5), [zoomBy]);
+  const reset = useCallback(() => setTransform({ scale: 1, x: 0, y: 0 }), []);
+
+  // Wheel has to be a manual, non-passive listener: React's onWheel is passive,
+  // and a passive listener cannot preventDefault, so the page would scroll out
+  // from under the board on every zoom.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return undefined;
+
+    const onWheel = (event) => {
+      event.preventDefault();
+      const frame = viewport.getBoundingClientRect();
+      // A trackpad pinch arrives as a ctrl-wheel; both it and a plain wheel
+      // mean the same thing here.
+      zoomBy(Math.exp(-event.deltaY * 0.0018), {
+        x: event.clientX - frame.left,
+        y: event.clientY - frame.top,
+      });
+    };
+
+    viewport.addEventListener("wheel", onWheel, { passive: false });
+    return () => viewport.removeEventListener("wheel", onWheel);
+  }, [zoomBy]);
+
+  // Pointer move/up are on the window, not the element: a finger that slides
+  // past the frame mid-drag must keep panning, and a mouse released outside it
+  // must still end the gesture.
+  useEffect(() => {
+    const onMove = (event) => {
+      const live = pointers.current;
+      if (!live.has(event.pointerId)) return;
+
+      const previous = live.get(event.pointerId);
+      const point = { x: event.clientX, y: event.clientY };
+      live.set(event.pointerId, point);
+
+      const [first, second] = [...live.values()];
+
+      if (live.size >= 2) {
+        // Pinch: the distance between the two fingers is the scale, and their
+        // midpoint is the focus, so the board follows the hand.
+        const frame = viewportRef.current?.getBoundingClientRect();
+        const spread = distance(first, second);
+        const centre = midpoint(first, second);
+
+        if (pinch.current && pinch.current.spread > 0) {
+          dragged.current = true;
+          zoomBy(spread / pinch.current.spread, {
+            x: centre.x - (frame?.left ?? 0),
+            y: centre.y - (frame?.top ?? 0),
+          });
+          panBy(centre.x - pinch.current.centre.x, centre.y - pinch.current.centre.y);
+        }
+
+        pinch.current = { spread, centre };
+        return;
+      }
+
+      const dx = point.x - previous.x;
+      const dy = point.y - previous.y;
+
+      if (!dragged.current) {
+        const travelled = origin.current
+          ? distance(point, origin.current)
+          : 0;
+        if (travelled < DRAG_THRESHOLD) return;
+        dragged.current = true;
+        setPanning(true);
+      }
+
+      panBy(dx, dy);
+    };
+
+    const onUp = (event) => {
+      pointers.current.delete(event.pointerId);
+      if (pointers.current.size < 2) pinch.current = null;
+      if (pointers.current.size === 0) {
+        origin.current = null;
+        setPanning(false);
+      }
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+  }, [panBy, zoomBy]);
+
+  const onPointerDown = useCallback((event) => {
+    // Only trackable pointers, and never a right-click.
+    if (event.button !== undefined && event.button > 0) return;
+
+    if (pointers.current.size === 0) {
+      dragged.current = false;
+      origin.current = { x: event.clientX, y: event.clientY };
+    }
+
+    pointers.current.set(event.pointerId, {
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }, []);
+
+  // The gesture guard. Capture phase, on the viewport, so a click born of a pan
+  // dies before it ever reaches the edge it happens to be sitting over.
+  const onClickCapture = useCallback((event) => {
+    if (!dragged.current) return;
+    dragged.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  return {
+    viewportRef,
+    transform,
+    panning,
+    zoomIn,
+    zoomOut,
+    reset,
+    canZoomIn: transform.scale < MAX_SCALE,
+    canZoomOut: transform.scale > MIN_SCALE,
+    viewportProps: { onClickCapture, onPointerDown, ref: viewportRef },
+  };
+};

--- a/src/app/(pages)/games/edge-case/page.js
+++ b/src/app/(pages)/games/edge-case/page.js
@@ -1,0 +1,31 @@
+import { ContextProvider } from "./context";
+import Game from "./Game";
+
+// "Edge Case" is the name; "dots and boxes" is what people search for. Both
+// stay in the description and keywords so the page is findable either way.
+export const metadata = {
+  title: "Edge Case — Dots and Boxes | Christopher Salinas Jr.",
+  description:
+    "Claim the edge. Close the case. Play dots and boxes in your browser — two to four players on one device, on a 5, 7 or 9 dot grid. Close a box and you go again.",
+  keywords: [
+    "dots and boxes",
+    "dots and boxes online",
+    "dots and boxes 2 player",
+    "pen and paper game",
+    "Edge Case",
+  ],
+  openGraph: {
+    title: "Edge Case — Dots and Boxes",
+    description:
+      "Claim the edge. Close the case. Two to four players, one device, and the rule that makes the game: close a box and you go again.",
+    type: "website",
+  },
+};
+
+export const EdgeCase = () => (
+  <ContextProvider>
+    <Game />
+  </ContextProvider>
+);
+
+export default EdgeCase;

--- a/src/app/(pages)/games/edge-case/players.js
+++ b/src/app/(pages)/games/edge-case/players.js
@@ -1,0 +1,79 @@
+/**
+ * Edge Case — who is who, and what colour they are.
+ *
+ * The engine only ever deals in opaque "slots". Everything a human needs to
+ * tell one slot from another — a name, an initial, a colour — lives here, in
+ * ONE shape that both the local hotseat game and the online room (#94) build:
+ *
+ *   { slot, name, initial, color, colorName }
+ *
+ * `color` is a CSS custom property reference, so it resolves inside inline SVG
+ * exactly as it does in CSS and stays in step with the site theme.
+ *
+ * Colour is never the only signal. Every player also carries an `initial`, and
+ * every claimed box is stamped with it — blue/purple and orange/green are the
+ * classic confusion pairs, and a colour-only board is unplayable for a chunk of
+ * people.
+ */
+
+import { MAX_PLAYERS } from "./_lib";
+
+// Slot colours in join order, straight out of the site palette. Four of them,
+// because four is the most players a game takes.
+export const PLAYER_PALETTE = Object.freeze([
+  { colorName: "Blue", color: "var(--component)", token: "--component" },
+  { colorName: "Purple", color: "var(--module)", token: "--module" },
+  { colorName: "Orange", color: "var(--selector)", token: "--selector" },
+  { colorName: "Green", color: "var(--type)", token: "--type" },
+]);
+
+// The slot ids a local hotseat game uses. Strings, not numbers: `state.scores`
+// is an object, and object keys stringify whether you meant them to or not.
+export const HOTSEAT_SLOTS = Object.freeze(["p1", "p2", "p3", "p4"]);
+
+/**
+ * Player descriptors for a list of slots, in join order.
+ *
+ * Names default to the colour ("Blue", "Purple", …) because on a shared device
+ * the colour IS the identity — nobody has typed a name in. An online room hands
+ * in real names instead; the initial follows whatever name it is given.
+ *
+ * @param {(String|Number)[]} slots - Slots in join order, at most MAX_PLAYERS
+ * @param {Object} [options]
+ * @param {String[]} [options.names] - Display names, positional, optional
+ * @returns {Object[]} One `{ slot, name, initial, color, colorName }` per slot
+ */
+export const createPlayers = (slots, { names = [] } = {}) =>
+  slots.slice(0, MAX_PLAYERS).map((slot, index) => {
+    const { color, colorName, token } = PLAYER_PALETTE[index];
+    const name = names[index] || colorName;
+
+    return {
+      slot,
+      name,
+      // Trimmed first, so " chris" still initials as "C" rather than a space.
+      initial: name.trim().charAt(0).toUpperCase() || colorName.charAt(0),
+      color,
+      colorName,
+      token,
+    };
+  });
+
+/**
+ * Slot → player descriptor, for the many components that hold a slot and need
+ * a colour. Falls back to a neutral descriptor rather than throwing, so a
+ * mismatched slot can never blank the board mid-game.
+ *
+ * @param {Object[]} players - Player descriptors
+ * @param {String|Number} slot - The slot to look up
+ * @returns {Object} A player descriptor
+ */
+export const playerFor = (players, slot) =>
+  players.find((player) => player.slot === slot) ?? {
+    slot,
+    name: "Player",
+    initial: "?",
+    color: "var(--foreground)",
+    colorName: "grey",
+    token: "--foreground",
+  };


### PR DESCRIPTION
Closes #93. Part of #89. Builds on the engine from #92 — **base is `feat/89-edge-case`, not `main`**.

`/games/edge-case` is playable: two to four players hotseat on one device, on a 5, 7 or 9 dot board. Tag line is on the page.

## The board

SVG, because the board is one coordinate system with three overlapping layers of geometry — box fills, thin lines, and tap targets several times their width — and only SVG lets those be sized independently of each other while scaling as one under zoom.

**Hit targets.** A drawn edge is 13 board units. Its tap target is 50 x 50 — a full quarter of a box. 50 is not arbitrary: a hit rect is inset from its dots by half its own breadth, which is exactly the point at which a horizontal target and the vertical target sharing its dot stop overlapping, so no tap is ever ambiguous, and 50 is the value that makes the resulting rect as large as it can be. On a 9-dot board at 390px that is 20px at rest and 71px at the 3.5x a pinch reaches in one gesture.

**Colour is never alone.** Every claimed box is stamped with its owner's initial. The fill is translucent and the letter full strength — a solid block of any palette colour drowns out the edges crossing it, and a letter wins its contrast against the page background more easily. Blue `--component`, purple `--module`, orange `--selector`, green `--type`; hotseat players are named for their colour, so "which one am I" has the same answer in the banner, the scoreboard and the box.

**Zoom and pan.** Pinch, scroll, and buttons; drag to pan. The transform is CSS on a wrapper rather than a rewritten `viewBox`, so the browser keeps mapping pointer coordinates for us and an edge is exactly as clickable at 5x as at 1x. A drag past 8px disqualifies the click it would otherwise end with — without that, every pan drops an edge where the finger came to rest.

**Keyboard and screen reader.** 144 edges share one tab stop (roving tabindex); arrows walk between them, enter or space commits. Focus previews the move in colour exactly as hover does. Drawn edges stay reachable — a keyboard player has to be able to survey the board, not just the moves still open. Claimed boxes are labelled with their owner, and a live region narrates each move, what it claimed and who is up.

## Where the state lives

No rule is reimplemented here. `_lib` decides every move, who owns what, whose turn it is and when it is over; this branch does not touch it.

`Board` owns no game state either. It is told what to draw and who to call, which is what lets #94 drop it into a networked room without surgery.

## Seams left for the other issues

**#94 — online play.** Replace `context/index.jsx` with a room-backed provider keeping the same value shape, `{ state: { game, players, ... }, dispatch }`. Then in `Game.jsx` two lines change:

```js
const youSlot = game.turn;          // hotseat: the device is whoever is up
const interactive = !game.finished; // becomes youSlot === game.turn && !game.finished
```

`<Board>` takes:

| prop | shape |
| --- | --- |
| `game` | an engine state |
| `players` | `[{ slot, name, initial, color, colorName, token }]` in join order |
| `youSlot` | the slot this device plays, or `null`/absent to spectate |
| `interactive` | may this device move right now |
| `onDraw` | `({ orientation, index }) => void` |
| `overlay` | node rendered over the board, sized to it |

`createPlayers(slots, { names })` in `players.js` builds the descriptors and takes real names when a lobby has them; `playerFor(players, slot)` is the lookup, and it falls back rather than throwing so a mismatched slot can never blank the board. Spectators come free: pass `interactive={false}`.

**#95 — endgame count-up.** `components/Endgame.jsx` is the mount point, rendered from `Game` through `Board`'s `overlay` prop and only when `result.finished`. Its props are the whole contract:

```
game         the finished engine state
players      descriptors in join order
result       getResult(game) — { standings, leaders, winner, tie, boxes, claimed, finished }
onPlayAgain  () => void
```

`standings` arrives sorted and ranked. Replace the body, keep the props. Two traps are noted in the file: `result.tie` is true on a live 0–0 game so it only means anything once `finished`, and the engine leaves `game.turn` on the final mover on purpose, so there is always a valid slot and colour on screen.

## Verified

`npm run lint` and `npm run build` clean. Then played it in Chrome:

- Full 5-dot two-player game to 16/16, ending 8–8, with the endgame overlay and Play again.
- Hover previews an undrawn edge in the mover's colour (`var(--component)` resolving to `#4fc1ff`); click commits.
- Closing one box grants another turn — a four-box chain ran on a single turn.
- One edge closing two boxes at once claims both and buys exactly one extra turn.
- Box fills carry initials; scores and the `n / n boxes` counter track.
- Pinch to 3.5x on a 390px viewport, scroll zoom, buttons, and drag-to-pan; clicking still lands correctly while zoomed, and a drag does not place an edge.
- Keyboard: tab to the board, arrows between edges, enter to claim.
- 390px wide with no horizontal overflow, and four players at 2x2 rather than four truncated names across.

## Judgement calls worth a second opinion

- **Hotseat players are named for their colour** (Blue, Purple, Orange, Green) so the initials are B/P/O/G — four distinct letters, and the colour is the identity when nobody has typed a name. `createPlayers` takes real names for #94.
- **Size and player count sit behind a Setup toggle** and start a new game when changed, rather than a setup screen before the first move. You land on a playable board. The panel now survives the restart so picking a size and then a player count is one action.
- **Drawn edges are neutral grey, not the drawer's colour.** The engine records who closed a box, not who drew an edge; inventing an owner would put a colour on the board that no rule backs. Only the most recent edge is tinted, so the last move is findable.
- **The board consumes wheel and touch gestures** (`touch-action: none`, `preventDefault` on wheel). Scrolling the page by swiping over the board does not work. Reasonable for a game board and required for pinch, but it is a real trade.
- **20px hit targets on a 9-dot board at phone width** before zooming. Below the 44px guideline at rest; the pinch answers it in one gesture and the zoom buttons are always visible. Growing the target further would mean letting perpendicular targets overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
