### PR TITLE
feat(EC): endgame count-up animation, winner, play again

### DIFF
--- a/src/app/(pages)/games/edge-case/components/Endgame.jsx
+++ b/src/app/(pages)/games/edge-case/components/Endgame.jsx
@@ -1,6 +1,109 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+import { clamp } from "lodash";
 
 import { playerFor } from "../players";
+import { VisuallyHidden } from "./VisuallyHidden";
+
+// How long the leader's counter runs. Every counter starts at the same instant
+// and ticks at the same rate, so this is also the longest any of them can take.
+const RACE_MS = 1900;
+
+// Floor and ceiling on a single box tick, so the rate stays watchable at both
+// ends of the board sizes: a 2-box lead does not flash past before the eye
+// lands on it, and a 64-box board does not crawl.
+const MIN_TICK_MS = 55;
+const MAX_TICK_MS = 260;
+
+const REDUCED_MOTION = "(prefers-reduced-motion: reduce)";
+
+const subscribeToMotion = (onChange) => {
+  const query = window.matchMedia(REDUCED_MOTION);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+};
+
+const motionSnapshot = () => window.matchMedia(REDUCED_MOTION).matches;
+
+// The page is prerendered, but this component only ever mounts on a finished
+// game — the server never renders it, so there is nothing to mismatch.
+const motionServerSnapshot = () => false;
+
+const usePrefersReducedMotion = () =>
+  useSyncExternalStore(subscribeToMotion, motionSnapshot, motionServerSnapshot);
+
+/**
+ * The count-up itself: ONE rAF loop, ONE piece of state.
+ *
+ * Deliberately one shared "boxes counted so far" step that each row clamps to
+ * its own score, rather than a timer per player. The whole reveal rests on the
+ * counters being in lockstep — everyone starts together, everyone ticks
+ * together, and the winner is simply the last one still moving. Separate timers
+ * drift apart within a second and turn the race into a staggered list.
+ *
+ * A CSS animation was the alternative and cannot do this: counting needs a
+ * whole number on screen every tick, and `@property` counter tricks are neither
+ * portable nor readable by assistive tech.
+ *
+ * It re-renders once per tick rather than once per frame, because the step is
+ * an integer — eight renders for an eight-box lead, not a hundred and ten.
+ *
+ * @param {Number} top - The leading score; the count is over when it is reached
+ * @param {Boolean} animate - False under `prefers-reduced-motion`
+ * @returns {Number} Boxes counted off so far, shared by every row
+ */
+const useCountUp = (top, animate) => {
+  const tickMs = clamp(RACE_MS / Math.max(top, 1), MIN_TICK_MS, MAX_TICK_MS);
+  const [step, setStep] = useState(() => (animate ? 0 : top));
+
+  useEffect(() => {
+    if (!animate) {
+      setStep(top);
+      return undefined;
+    }
+
+    setStep(0);
+
+    let frame = 0;
+    const start = performance.now();
+
+    const tick = (now) => {
+      const counted = Math.min(top, Math.floor((now - start) / tickMs));
+      // Functional update so an unchanged step bails out of rendering entirely.
+      setStep((current) => (current === counted ? current : counted));
+
+      if (counted < top) {
+        frame = requestAnimationFrame(tick);
+      }
+    };
+
+    frame = requestAnimationFrame(tick);
+
+    // A rematch starts the instant the button is pressed, which unmounts this
+    // mid-count — never leave a frame scheduled against a dead component.
+    return () => cancelAnimationFrame(frame);
+  }, [animate, tickMs, top]);
+
+  return step;
+};
+
+const list = (items) =>
+  items.length < 2
+    ? items.join("")
+    : `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+
+const reveal = keyframes`
+  from { opacity: 0; transform: translateY(-0.25rem); }
+  to   { opacity: 1; transform: translateY(0); }
+`;
 
 const Overlay = styled.div`
   align-items: center;
@@ -22,9 +125,22 @@ const Headline = styled.h2`
   font-size: 1.5rem;
   line-height: 1.9rem;
   margin: 0;
+  /* Held open from the first frame. The verdict lands only once the last
+     counter stops, and the standings underneath must not jump when it does. */
+  min-height: 1.9rem;
 
   .slot {
     color: var(--slot);
+  }
+
+  .verdict {
+    animation: ${reveal} 260ms ease-out both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .verdict {
+      animation: none;
+    }
   }
 `;
 
@@ -41,9 +157,37 @@ const Standings = styled.ol`
 
 const Row = styled.li`
   align-items: center;
+  border-radius: 0.4rem;
   display: flex;
   flex-flow: row nowrap;
   gap: 0.5rem;
+  /* The bar sits behind the row, so it needs a stacking context and a little
+     breathing room to read as a fill rather than a border. */
+  overflow: hidden;
+  padding: 0.2rem 0.35rem;
+  position: relative;
+
+  /* The race, made visible. The number is the truth, but a bar growing at the
+     same rate in four lanes is what makes "still counting" legible from across
+     a room — and it is the same data, so it costs nothing in honesty. */
+  .lane {
+    background-color: var(--slot);
+    bottom: 0;
+    left: 0;
+    opacity: 0.16;
+    position: absolute;
+    top: 0;
+    /* No CSS transition: the width is driven by the same rAF step as the
+       number, and a transition would let the bar lag behind its own count. */
+    z-index: 0;
+  }
+
+  .chip,
+  .name,
+  .score {
+    position: relative;
+    z-index: 1;
+  }
 
   .chip {
     align-items: center;
@@ -51,6 +195,7 @@ const Row = styled.li`
     border-radius: 0.35rem;
     color: var(--background);
     display: inline-flex;
+    flex: 0 0 auto;
     font-size: 0.85rem;
     font-weight: 700;
     height: 1.5rem;
@@ -61,12 +206,23 @@ const Row = styled.li`
   .name {
     color: var(--slot);
     flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
     text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .score {
+    flex: 0 0 auto;
     font-variant-numeric: tabular-nums;
     font-weight: 700;
+  }
+
+  /* Whoever is still counting when the others have stopped. Marked once the
+     race is over, so it never previews the answer. */
+  &.leader .score {
+    color: var(--slot);
   }
 `;
 
@@ -87,12 +243,9 @@ const Again = styled.button`
 `;
 
 /**
- * The end of the game.
+ * The end of the game — the count-up, the verdict, and the rematch.
  *
- * ─────────────────────────────────────────────────────────────────────────────
- * SEAM FOR #95 — the count-up animation.
- *
- * This is the mount point, and the props below are the whole contract:
+ * Props (the contract with `Game`, and with an online room):
  *
  *   game        the finished engine state
  *   players     player descriptors in join order — { slot, name, initial, color }
@@ -101,49 +254,118 @@ const Again = styled.button`
  *   onPlayAgain () => void — dispatches a fresh game with the same settings
  *
  * `Game` renders this inside the board frame, absolutely positioned over the
- * board, and only when `result.finished` is true. What is below is a plain
- * static result: replace the body, keep the props.
+ * board, and only when `result.finished` is true.
  *
- * Two things to know before animating: `result.tie` is TRUE on a live 0–0 game,
- * so it only means anything once `finished`; and the engine deliberately leaves
- * `game.turn` on the final mover, so there is always a valid slot and colour on
- * screen.
- * ─────────────────────────────────────────────────────────────────────────────
+ * Every counter starts at zero at the same instant and climbs at the same rate,
+ * so the one still moving when the rest have stopped is the winner. That is the
+ * announcement, and the verdict underneath only confirms what the race showed —
+ * which is why nothing names a winner until the last counter lands.
+ *
+ * Ties are reported as ties. `result.winner` is null whenever the top score is
+ * shared, and the engine will not break it; neither will this. (`result.tie` is
+ * also true on a live 0–0 game, which is harmless here — the overlay only
+ * mounts once `finished`.)
+ *
+ * Nothing is conveyed by motion alone: the verdict is text, the standings are a
+ * list, every player carries their initial next to their colour, and the final
+ * result reaches a screen reader through the live region at the bottom — once,
+ * when the count lands, rather than on every tick.
  */
 export const Endgame = ({ game, onPlayAgain, players, result }) => {
-  const { standings, leaders, tie, winner } = result;
+  const { leaders, standings, tie, winner } = result;
+
+  const reducedMotion = usePrefersReducedMotion();
+  const top = standings[0]?.score ?? 0;
+  const step = useCountUp(top, !reducedMotion);
+  const done = step >= top;
+
   const champion = playerFor(players, winner ?? leaders[0]);
+  const boxes = game.owners.length;
+
+  const summary = useMemo(() => {
+    const verdict = tie
+      ? `Tie at ${top} ${top === 1 ? "box" : "boxes"} between ${list(
+          leaders.map((slot) => playerFor(players, slot).name)
+        )}.`
+      : `${champion.name} wins with ${top} of ${boxes} boxes.`;
+
+    const scores = standings.map(({ slot, score }) => {
+      const player = playerFor(players, slot);
+      return `${player.name} ${score}`;
+    });
+
+    return `Game over. ${verdict} Final scores: ${list(scores)}.`;
+  }, [boxes, champion.name, leaders, players, standings, tie, top]);
+
+  // The live region is mounted empty and filled a frame after the count lands.
+  // Filling it on the same commit it mounts on is the one case several screen
+  // readers skip, and holding it back until `done` is what keeps the tick-by-
+  // tick numbers out of it.
+  const [announcement, setAnnouncement] = useState("");
+
+  useEffect(() => {
+    if (!done) {
+      return undefined;
+    }
+
+    const frame = requestAnimationFrame(() => setAnnouncement(summary));
+    return () => cancelAnimationFrame(frame);
+  }, [done, summary]);
 
   return (
-    <Overlay>
+    <Overlay aria-label="Final result" role="dialog">
       <Headline style={{ "--slot": champion.color }}>
-        {tie ? (
-          <>
-            Tied at {standings[0].score} —{" "}
-            {leaders
-              .map((slot) => playerFor(players, slot).name)
-              .join(" and ")}
-          </>
-        ) : (
-          <>
-            <span className="slot">{champion.name}</span> wins
-          </>
+        {done && (
+          <span className="verdict">
+            {tie ? (
+              <>
+                Tie at {top} —{" "}
+                {leaders.map((slot, index) => {
+                  const player = playerFor(players, slot);
+
+                  return (
+                    <span key={slot}>
+                      {index > 0 && (index === leaders.length - 1 ? " and " : ", ")}
+                      <span style={{ color: player.color }}>{player.name}</span>
+                    </span>
+                  );
+                })}
+              </>
+            ) : (
+              <>
+                <span className="slot">{champion.name}</span> wins
+              </>
+            )}
+          </span>
         )}
       </Headline>
 
       <Standings>
         {standings.map(({ slot, score }) => {
           const player = playerFor(players, slot);
+          // Every row counts from the same shared step and simply stops at its
+          // own score. This one line is the whole simultaneity guarantee.
+          const count = Math.min(score, step);
 
           return (
-            <Row key={slot} style={{ "--slot": player.color }}>
+            <Row
+              className={done && leaders.includes(slot) ? "leader" : undefined}
+              key={slot}
+              style={{ "--slot": player.color }}
+            >
+              <span
+                aria-hidden="true"
+                className="lane"
+                style={{ width: `${boxes > 0 ? (count / boxes) * 100 : 0}%` }}
+              />
               <span aria-hidden="true" className="chip">
                 {player.initial}
               </span>
               <span className="name">{player.name}</span>
               <span className="score">
-                {score}
-                <span aria-hidden="true"> / {game.owners.length}</span>
+                {count}
+                <span aria-hidden="true"> / {boxes}</span>
+                <VisuallyHidden> {count === 1 ? "box" : "boxes"}</VisuallyHidden>
               </span>
             </Row>
           );
@@ -153,6 +375,10 @@ export const Endgame = ({ game, onPlayAgain, players, result }) => {
       <Again autoFocus onClick={onPlayAgain} type="button">
         Play again
       </Again>
+
+      <VisuallyHidden aria-atomic="true" aria-live="polite" role="status">
+        {announcement}
+      </VisuallyHidden>
     </Overlay>
   );
 };


### PR DESCRIPTION
Closes #95. Part of #89. Based on `feat/89-edge-case`.

The endgame overlay stops being a static scoreboard and becomes the reveal the epic asked for.

## What it does

When the last edge is drawn, every player's box count starts at **zero at the same instant** and climbs at the same rate. Each counter stops at its own score, so the one still moving when the others have stopped is the winner. Nothing names a winner until the last counter lands — the race is the announcement, and the verdict underneath only confirms what it showed.

A translucent lane in each player's colour grows behind their row at the same rate as their number. Same data, no extra claim: it is what makes "still counting" legible from across a table, which is the point of the whole feature.

## How the animation works

One `requestAnimationFrame` loop and one piece of state for the whole overlay: a shared "boxes counted so far" step that each row clamps to its own score. That single `Math.min(score, step)` **is** the simultaneity guarantee — per-player timers were the alternative and drift apart within a second, which would quietly turn the race back into a staggered list.

- Re-renders once per **tick**, not per frame — eight renders for an eight-box lead, not a hundred and ten.
- Cancels the pending frame on unmount, so pressing **Play again** mid-count leaves nothing scheduled against a dead component.
- Tick length is `RACE_MS / topScore`, clamped, so a 5-dot board and a 9-dot board both take about 1.9s and neither flashes past nor crawls.

CSS was considered and rejected: counting needs a whole number on screen every tick, and `@property` counter tricks are neither portable nor readable by assistive tech.

## Ties

`getResult` leaves `winner` null whenever the top score is shared and refuses to break it; so does this. A tie reads **"Tie at 8 — Blue and Purple"**, each name in its own colour, with every tied player's score marked. No one gets picked.

## Play again

Fires the `onPlayAgain` callback and nothing else — clearing the board while keeping the room, the players and their colours is the provider's job, not the overlay's.

## Accessibility

- **`prefers-reduced-motion`** is read through `matchMedia` (and the verdict's fade through the CSS media query). Under it the final scores and the verdict are on screen on the first frame; there is no count-up.
- The result reaches a screen reader through **one** polite live region, filled once when the count lands — not on every tick. The overlay is a labelled `role="dialog"`.
- Colour is never the only channel: every player carries their initial next to their colour, matching the board.

## Blast radius

One file: `src/app/(pages)/games/edge-case/components/Endgame.jsx`. The props contract (`game`, `players`, `result`, `onPlayAgain`) is unchanged, so the online lobby work on #94 can mount it exactly as `Game` does. Nothing under `context/`, `board/`, `_lib/`, `Game.jsx` or `src/lib/realtime/` was touched. No new dependencies.

## Verified

`npm run lint` and `npm run build` clean. Driven in a real dev server on a hotseat 5-dot (4×4, 16 box) game played to completion — the overlay was reached genuinely, never forced.

Sampling the DOM through a real reveal, 2 players:

```
t=44    Blue 0   Purple 0     headline ""
t=362   Blue 2   Purple 2     headline ""      <- lockstep
t=679   Blue 4   Purple 4     headline ""      <- Blue stops here
t=1154  Blue 4   Purple 7     headline ""      <- only the leader is moving
t=1946  Blue 4   Purple 12    headline "Purple wins"
t=1949  live region: "Game over. Purple wins with 12 of 16 boxes.
                      Final scores: Purple 12 and Blue 4."
```

Also confirmed:

- **Play again** clears the board (40 open edges, 0/16) and keeps both players and their colours.
- **Tie**: an 8–8 finish, reached by replaying to completion until one came up, reads "Tie at 8 — Blue and Purple" and announces "Game over. Tie at 8 boxes between Blue and Purple." — no winner named.
- **Reduced motion**: on the first frame the overlay exists the scores are already final and the verdict is already there.
- **Four players**: all four colours and initials, correct rank order, and the announcement lists them "Blue 9, Purple 4, Orange 2 and Green 1."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
