### PR TITLE
content(Privacy and Terms): describe the multiplayer games, accounts, and local storage

### DIFF
--- a/src/app/(pages)/privacy-policy/page.js
+++ b/src/app/(pages)/privacy-policy/page.js
@@ -7,106 +7,194 @@ const PrivacyPolicy = () => {
   return (
     <Section sx={{ gap: 3 }}>
       <Title>Privacy Policy</Title>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
-        Last Updated: April 6, 2025
+        Last Updated: August 3, 2026
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         This Privacy Policy describes how I collect, use, and share your personal information when you visit csalinas.dev (the &quot;Website&quot;).
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Information I Collect
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        When you visit the Website, I may collect certain information about your device, including information about your web browser, IP address, time zone, and some of the cookies that are installed on your device.
+        When you visit the Website, my server receives the information any web request carries: your IP address, your browser and device type, and the page you asked for. The analytics service described below also records which pages you view and what site or search referred you.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        Additionally, as you browse the Website, I may collect information about the individual web pages that you view, what websites or search terms referred you to the Website, and information about how you interact with the Website.
+        Your IP address is additionally used, in memory only, to rate limit a few endpoints — creating a multiplayer room, for example — so that one visitor cannot flood them. Those counters expire within a minute, are lost when the server restarts, and are never written to the database.
       </Typography>
-      
+
+      <Typography variant="h4" component="h2" gutterBottom>
+        Accounts
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        An account is optional. Nothing on the Website requires one; signing in to Wordleverse saves your game history to the database so it follows you between devices, and that is the whole of it.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        If you register with an email address and password, I store your name, your email address, and a hashed version of your password — the password itself is never stored. If you sign in with Google or GitHub instead, I store the name, email address, and profile image that service returns, plus the tokens needed to keep you signed in. Registration sends you a verification email, which means your address also passes through my email provider.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        While you are signed in, the Wordleverse games you play are saved against your account: the date, the word, your guesses, the board, and your streak. Signed out, those same games are kept only in your browser.
+      </Typography>
+
+      <Typography variant="h4" component="h2" gutterBottom>
+        Multiplayer Games
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Tic-Tac-Overflow and Edge Case can be played online against other people. Playing online creates a room — one database row, identified by a four-character code — holding the game in progress and, for each player, a seat number, a colour, a display name, and the times they joined and were last seen. No account is involved, and nothing in a room is linked to one even if you happen to be signed in.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        A room is deleted 60 minutes after its last move. Nothing is archived first: when the room goes, the game, the names, and the seats go with it, and requests for it are answered as though it never existed.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Anyone holding a room&apos;s code can watch that game and see the display names in it, whether or not they are playing. Codes are four characters and are listed nowhere, but they are not secret either — share one only with the people you want in the game.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Edge Case asks for a display name in its lobby and remembers your last one in your browser; Tic-Tac-Overflow does not ask, and calls you Player 1 or Player 2. Whatever you type is shown to everyone in the room, so treat it as public and do not put anything in it you would not want a stranger to read.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        The Website needs some way to tell which browser holds which seat, and it does not use an account for that. The first time you play online, your browser generates a random identifier and saves it under CSALINAS-PLAYER-TOKEN in local storage. It travels with your moves so the server can work out whose turn was just taken, which is also how you get your seat back after a refresh or a dropped connection.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        That identifier is not an account. It is not connected to one if you have one, it carries no information about you, and it is not used for advertising or to follow you across other websites — only csalinas.dev can read it, and only the rooms you have joined mean anything by it. Clearing your browser&apos;s site data removes it, and the next room you join will simply treat you as a new player.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Keeping a game live uses one more short-lived credential: a single-use ticket, good for about thirty seconds, that lets your browser open the streaming connection. Tickets are held in the server&apos;s memory and are never written to the database.
+      </Typography>
+
       <Typography variant="h4" component="h2" gutterBottom>
         How I Use Your Information
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I use the information I collect to:
       </Typography>
-      
+
       <List>
-        <ListItem>Improve and optimize my Website</ListItem>
-        <ListItem>Understand user preferences and trends</ListItem>
-        <ListItem>Prevent fraudulent activity and improve security</ListItem>
-        <ListItem>Analyze the use of my services</ListItem>
+        <ListItem>Run the Website and the games on it</ListItem>
+        <ListItem>Keep you signed in and save your game history if you have an account</ListItem>
+        <ListItem>Understand which pages and games people actually use</ListItem>
+        <ListItem>Rate limit requests and otherwise protect the Website from abuse</ListItem>
       </List>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Sharing Your Information
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I may share your personal information with third-party service providers to help me operate my Website, such as web hosting providers, analytics services, and other service providers.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        I may also disclose your personal information if required by law or if I believe that such action is necessary to comply with legal obligations or protect and defend my rights or property.
+        I do not sell your personal information. I may disclose it if required by law or if I believe that such action is necessary to comply with legal obligations or protect and defend my rights or property.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
-        Cookies and Tracking Technologies
+        Cookies and Local Storage
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        I use cookies and similar tracking technologies to track activity on my Website and hold certain information. Cookies are files with a small amount of data that may include an anonymous unique identifier.
+        The Website sets a cookie when you sign in — that is how a session survives a page load. The analytics and anti-spam services described below set cookies of their own. There are no advertising cookies.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent. However, if you do not accept cookies, you may not be able to use some portions of my Website.
+        Most of what the Website remembers about you is kept in your browser&apos;s local storage rather than in a cookie:
       </Typography>
-      
+
+      <List>
+        <ListItem>WORDLEVERSE-… — your Wordleverse games, while you are playing signed out</ListItem>
+        <ListItem>expert — whether Wordleverse expert mode is switched on</ListItem>
+        <ListItem>HASHTAG-… — your saved Hashtag puzzles</ListItem>
+        <ListItem>TICTACOVERFLOW-PREVIEW — whether Tic-Tac-Overflow hints at the mark your next move will clear</ListItem>
+        <ListItem>EDGECASE-NAME — the display name you last used in Edge Case</ListItem>
+        <ListItem>CSALINAS-PLAYER-TOKEN — the multiplayer identifier described above</ListItem>
+      </List>
+
+      <Typography variant="body1" paragraph>
+        These stay on your device unless the Website has a reason to send them: signing in moves your saved Wordleverse games onto your account, and your Edge Case name goes to a room when you join one. Clearing site data for csalinas.dev deletes all of it. You can also instruct your browser to refuse cookies; you will still be able to read the site and play the games that do not need an account.
+      </Typography>
+
       <Typography variant="h4" component="h2" gutterBottom>
         Third-Party Services
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        My Website may contain links to other websites that are not operated by me. If you click on a third-party link, you will be directed to that third party&apos;s site. I strongly advise you to review the Privacy Policy of every site you visit.
+        The Website loads a handful of third-party services in your browser. Each of them will see your IP address and the usual request information:
       </Typography>
-      
+
+      <List>
+        <ListItem>Google Analytics, loaded through Google Tag Manager, for page view statistics</ListItem>
+        <ListItem>Google reCAPTCHA, on the registration form, to keep automated sign-ups out</ListItem>
+        <ListItem>Font Awesome, which serves the site&apos;s icons</ListItem>
+        <ListItem>github-contributions-api.jogruber.de, on the GitHub page only, which supplies the contribution graph</ListItem>
+        <ListItem>Google or GitHub, but only if you choose to sign in with one of them</ListItem>
+      </List>
+
+      <Typography variant="body1" paragraph>
+        Content for the project pages comes from Hygraph, but my server fetches it — your browser never contacts them.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        My Website may also contain links to other websites that are not operated by me. If you click on a third-party link, you will be directed to that third party&apos;s site. I strongly advise you to review the Privacy Policy of every site you visit.
+      </Typography>
+
       <Typography variant="body1" paragraph>
         I have no control over and assume no responsibility for the content, privacy policies, or practices of any third-party sites or services.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Data Retention
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        I will retain your personal information only for as long as is necessary for the purposes set out in this Privacy Policy.
+        How long something is kept depends on what it is:
       </Typography>
-      
+
+      <List>
+        <ListItem>Multiplayer rooms — 60 minutes after the last move, then deleted outright</ListItem>
+        <ListItem>Streaming tickets and rate limit counters — seconds to a minute, in memory only</ListItem>
+        <ListItem>Your account and its Wordleverse history — for as long as the account exists</ListItem>
+        <ListItem>Anything in local storage — until you clear it</ListItem>
+      </List>
+
+      <Typography variant="body1" paragraph>
+        There is no delete-my-account button yet. Email me at the address below and I will delete your account and its game history.
+      </Typography>
+
       <Typography variant="h4" component="h2" gutterBottom>
         Changes to This Privacy Policy
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I may update my Privacy Policy from time to time. I will notify you of any changes by posting the new Privacy Policy on this page and updating the &quot;Last Updated&quot; date.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Contact Me
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         If you have any questions about this Privacy Policy, please contact me at:
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         Email: contact@csalinas.dev
       </Typography>

--- a/src/app/(pages)/terms/page.js
+++ b/src/app/(pages)/terms/page.js
@@ -7,115 +7,166 @@ const TermsAndConditions = () => {
   return (
     <Section sx={{ gap: 3 }}>
       <Title>Terms and Conditions</Title>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
-        Last Updated: April 6, 2025
+        Last Updated: August 3, 2026
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         Please read these Terms and Conditions (&quot;Terms&quot;) carefully before using the csalinas.dev website (&quot;Website&quot;) operated by me, Christopher Salinas Jr.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         Your access to and use of the Website is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all visitors, users, and others who access or use the Website.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         By accessing or using the Website, you agree to be bound by these Terms. If you disagree with any part of the Terms, you may not access the Website.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Intellectual Property
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         The Website and its original content, features, and functionality are and will remain my exclusive property and that of my licensors. The Website is protected by copyright, trademark, and other laws of both the United States and foreign countries.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         My trademarks and trade dress may not be used in connection with any product or service without my prior written consent.
       </Typography>
-      
+
+      <Typography variant="h4" component="h2" gutterBottom>
+        Accounts
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        An account is optional and exists for one reason: to save your Wordleverse history across devices. You are responsible for keeping your credentials to yourself and for anything done with your account. Tell me if you think someone else is using it.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Sign up with your own email address, and do not register an account on someone else&apos;s behalf.
+      </Typography>
+
       <Typography variant="h4" component="h2" gutterBottom>
         User Content
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        My Website may allow you to post, link, store, share and otherwise make available certain information, text, graphics, videos, or other material. You are responsible for the content that you post on or through the Website, including its legality, reliability, and appropriateness.
+        The only thing you can put on the Website that other people see is a display name in an online game. There is no comment system, no public profile, and nothing to upload.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
-        By posting content on or through the Website, you represent and warrant that: (i) the content is yours and/or you have the right to use it and the right to grant me the rights and license as provided in these Terms, and (ii) that the posting of your content on or through the Website does not violate the privacy rights, publicity rights, copyrights, contract rights or any other rights of any person.
+        You are responsible for the name you choose. Do not use one that is someone else&apos;s personal information, that infringes anyone&apos;s rights, or that you would not want a stranger to read — everyone in the room, including anyone watching it, will see it.
       </Typography>
-      
+
+      <Typography variant="h4" component="h2" gutterBottom>
+        Online Games
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Tic-Tac-Overflow and Edge Case can be played online with other people. Each game lives in a room with a four-character code, and anyone holding that code can join it or watch it. Codes are listed nowhere, but they are short and they are not secret — share one only with the people you mean to play with.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Nothing in a room is moderated. Nobody reviews a display name before it appears, there is no filter, and there is no report button. This is a hobby project run by one person, and I would rather say that plainly than imply a safety net that does not exist.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        If someone in a room is behaving in a way you would rather not see, the remedy is to leave and start a new game with a fresh code. Rooms disappear an hour after their last move in any case, and I may delete any room at any time, for any reason, without notice.
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        Games in progress are not saved and cannot be recovered once a room is gone. Play them as the hobby projects they are, and not as something to rely on.
+      </Typography>
+
+      <Typography variant="h4" component="h2" gutterBottom>
+        Acceptable Use
+      </Typography>
+
+      <Typography variant="body1" paragraph>
+        While using the Website, please do not:
+      </Typography>
+
+      <List>
+        <ListItem>Use a display name to harass, impersonate, or expose anyone</ListItem>
+        <ListItem>Join rooms you were not invited to in order to disrupt other people&apos;s games</ListItem>
+        <ListItem>Automate requests, flood the games, or work around the rate limits</ListItem>
+        <ListItem>Attempt to access accounts, rooms, or data that are not yours</ListItem>
+      </List>
+
       <Typography variant="h4" component="h2" gutterBottom>
         Links To Other Websites
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         My Website may contain links to third-party websites or services that are not owned or controlled by me.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I have no control over, and assume no responsibility for, the content, privacy policies, or practices of any third-party websites or services. You further acknowledge and agree that I shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with the use of or reliance on any such content, goods, or services available on or through any such websites or services.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I strongly advise you to read the terms and conditions and privacy policies of any third-party websites or services that you visit.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Termination
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I may terminate or suspend access to my Website immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the Terms.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         All provisions of the Terms which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Disclaimer
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         Your use of the Website is at your sole risk. The Website is provided on an &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; basis. The Website is provided without warranties of any kind, whether express or implied, including, but not limited to, implied warranties of merchantability, fitness for a particular purpose, non-infringement, or course of performance.
       </Typography>
-      
+
+      <Typography variant="body1" paragraph>
+        That applies to the games in particular. They are side projects. They may be changed, broken, or taken down at any time, and no game, room, or saved history is guaranteed to still be there tomorrow.
+      </Typography>
+
       <Typography variant="h4" component="h2" gutterBottom>
         Governing Law
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         These Terms shall be governed and construed in accordance with the laws of the United States, without regard to its conflict of law provisions.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         My failure to enforce any right or provision of these Terms will not be considered a waiver of those rights. If any provision of these Terms is held to be invalid or unenforceable by a court, the remaining provisions of these Terms will remain in effect.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Changes to Terms
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         I reserve the right, at my sole discretion, to modify or replace these Terms at any time. If a revision is material, I will try to provide at least 30 days&apos; notice prior to any new terms taking effect.
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         By continuing to access or use my Website after those revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, please stop using the Website.
       </Typography>
-      
+
       <Typography variant="h4" component="h2" gutterBottom>
         Contact Me
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         If you have any questions about these Terms, please contact me at:
       </Typography>
-      
+
       <Typography variant="body1" paragraph>
         Email: contact@csalinas.dev
       </Typography>


### PR DESCRIPTION
## The answer: yes, and more than the multiplayer games

Both pages were dated April 6, 2025 and were generic boilerplate. Read against what the code does today, they were not just missing the multiplayer games — they were inaccurate about most of the site.

**Terms actually needed exactly one new thing**, and it is the one the issue guessed: display names are user content, typed by one person and shown to strangers. Nothing else about the games creates an obligation the old Terms didn't already cover.

**Privacy needed a lot more.** It described a site with cookies and nothing else. It never mentioned accounts, never mentioned localStorage — which is where nearly everything the site remembers about you lives — and named none of the third parties the browser actually talks to.

## What changed

### Privacy Policy

- **Multiplayer Games** (new). The `GameRoom` row and what it holds (`code`, `game`, `state`, and per player a slot, name, colour, `connectedAt`/`lastSeenAt`). Deleted 60 minutes after the last accepted action, not archived. Spectating: anyone with the 4-character code sees the board and the names. Stream tickets: in memory, single use, ~30s, never written to the database.
- **The player token**, described honestly: a `crypto.randomUUID()` in `CSALINAS-PLAYER-TOKEN`, what it does (resolves your seat, which is what makes rejoin work), and explicitly what it is *not* — not an account, not linked to one if you have one, not readable by other origins, not advertising or cross-site tracking. Clearing site data removes it.
- **Accounts** (new). The old policy did not mention them at all. Now: optional, exists only to persist Wordleverse history; email/password stores a bcrypt hash; Google/GitHub store name, email, image and the NextAuth tokens; registration sends a verification email.
- **Cookies and Local Storage** (renamed from "Cookies and Tracking Technologies"). The previous text implied cookies were the whole story. Every key is now listed: `WORDLEVERSE-…`, `expert`, `HASHTAG-…`, `TICTACOVERFLOW-PREVIEW`, `EDGECASE-NAME`, `CSALINAS-PLAYER-TOKEN` — with the two cases where local data does leave the browser (sign-in migrates saved Wordleverse games; your Edge Case name goes to the room).
- **Third-Party Services** now names them instead of gesturing at "service providers": Google Analytics via GTM, reCAPTCHA on registration, the Font Awesome kit, Google/GitHub on OAuth sign-in. Hygraph is noted as server-side only.
- **Data Retention** is now per data type — rooms 60 min, tickets/rate-limit counters seconds, account data until deleted, localStorage until cleared — instead of "as long as is necessary".
- **IP addresses**: the rate limiter (`src/lib/rate-limit.js`) keys on IP in memory, expires within a minute, and is never written to the database. Said so plainly rather than leaving it implied.

### Terms and Conditions

- **User Content** rewritten. It claimed you could post "text, graphics, videos, or other material". You cannot. The only user content on this site is a display name in an online game, so that is what it now says, along with your responsibility for it.
- **Online Games** (new). Room codes are short, unlisted, and not secret. **Nothing in a room is moderated** — no filter, no review before a name appears, no report button — stated plainly rather than implied away. The remedy is to leave and start a fresh room; rooms die an hour after the last move anyway, and I may delete any room at any time.
- **Accounts** (new) and **Acceptable Use** (new), both short.
- The Disclaimer gained one sentence saying the games in particular are side projects that may break or vanish.
- Both pages: Last Updated → August 3, 2026.

## Things the issue did not anticipate

1. **Display names are Edge Case only.** Tic-Tac-Overflow's `createRoom({ game: TTO_GAME_ID })` passes no name; `cleanName` falls back to `Player 1`/`Player 2`, so nobody types anything there. Both pages say this rather than implying both games ask for a name.
2. **There is a seventh localStorage key the issue's list missed**: `EDGECASE-NAME` (`edge-case/online/preferences.js`), which remembers your last display name across games. It is now listed.
3. **`github-contributions-api.jogruber.de`** — `react-github-calendar` on `/github` fetches from a third-party API in the visitor's browser. That was an undisclosed third-party request and is now listed.
4. **There is no contact form.** The reCAPTCHA in this repo protects the *registration* endpoint (`/api/auth/register`), not a contact form, and there is no contact page at all — so nothing was written about one.
5. **There is no self-serve account deletion** — `/profile` only unlinks OAuth providers. Rather than claim a right the site cannot honour, the policy says there is no button yet and to email.

## Deliberately not done

- **Governing Law still says "the laws of the United States"**, which is not a real choice-of-law clause (it should name a state). Changing it is a legal decision, not a factual correction, so I left it and am flagging it here.
- No compliance claims (GDPR/CCPA/COPPA), no invented data-subject rights, no age gate. This is a personal site with hobby games and the pages now read that way.

## Verification

`npm run lint` and `npm run build` both clean. Rendered both pages on a dev server at desktop width and at a 386px viewport — no horizontal overflow at either (`scrollWidth === clientWidth`), long keys like `TICTACOVERFLOW-PREVIEW` wrap at the hyphen, and the `Section`/`Title`/`Typography`/`List` structure is untouched, so nothing about the pages' look changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
