### PR TITLE
Drop four in a row: the Connect 404 engine

### DIFF
--- a/src/app/(pages)/games/connect-404/_lib/board.js
+++ b/src/app/(pages)/games/connect-404/_lib/board.js
@@ -1,0 +1,130 @@
+/**
+ * Connect 404 — board geometry.
+ *
+ * ┌───────────────────────────────────────────────────────────────────────────┐
+ * │ COORDINATE CONVENTION — read this before rendering, hit-testing or        │
+ * │ animating. Do not re-derive it; three renderers disagreeing about which   │
+ * │ end of a column is the floor is three different bugs.                     │
+ * └───────────────────────────────────────────────────────────────────────────┘
+ *
+ * ROW 0 IS THE BOTTOM. `col` grows RIGHTWARD, `row` grows UPWARD.
+ *
+ * The board is stored COLUMN-MAJOR as `state.columns`: one array per column,
+ * holding only the pieces actually in it. `columns[c][0]` is the piece resting
+ * on the floor of column c, and a new piece is PUSHED ON TOP. That is gravity,
+ * expressed as `Array.prototype.push` — a column is always a contiguous stack
+ * from the bottom, and a floating piece is unrepresentable rather than merely
+ * illegal.
+ *
+ * A column's LENGTH is therefore both its height and the row a new piece would
+ * land on, which is all `landingRow` is.
+ *
+ *          col  0   1   2   3   4   5   6
+ *              ┌───┬───┬───┬───┬───┬───┬───┐
+ *      row 5   │   │   │   │   │   │   │   │   ← TOP    (columns[c][5])
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 4   │   │   │   │   │   │   │   │
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 3   │   │   │   │   │   │   │   │
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 2   │   │   │ B │   │   │   │   │   columns[2] = [A, R, B]
+ *              ├───┼───┼───┼───┼───┼───┼───┤              length 3
+ *      row 1   │   │ R │ R │   │   │   │   │              landingRow = 3
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 0   │ R │ A │ A │   │   │   │   │   ← BOTTOM (columns[c][0])
+ *              └───┴───┴───┴───┴───┴───┴───┘
+ *                                 ▲
+ *                                 └── columns[4] = [], landingRow = 0
+ *
+ * A CELL is the pair `[col, row]`, in that order — the same order `lastMove`
+ * and every entry of `winningLine` use. `cellAt(state, col, row)` is the slot
+ * occupying it, or null.
+ *
+ * Rendering top-down (which is how a board is drawn) means walking rows
+ * DESCENDING: `for (let row = rows - 1; row >= 0; row -= 1)`. Do not flip the
+ * stored data to make a render loop read nicer; flip the loop.
+ *
+ * Every helper below takes a `board`: any object carrying `cols`, `rows` and
+ * `columns`. A game state is a valid board, so `landingRow(state, 3)` works
+ * as-is.
+ */
+
+/** Whether `col` names a column this board actually has. */
+export const isColumnInRange = ({ cols }, col) =>
+  Number.isInteger(col) && col >= 0 && col < cols;
+
+/** Whether `row` names a row this board actually has. */
+export const isRowInRange = ({ rows }, row) =>
+  Number.isInteger(row) && row >= 0 && row < rows;
+
+/**
+ * How many pieces are stacked in a column.
+ * @param {Object} board - Anything with `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Number} 0…rows, and 0 for a column that does not exist
+ */
+export const columnHeight = ({ columns }, col) => columns[col]?.length ?? 0;
+
+/**
+ * Whether a column has no room left.
+ * @param {Object} board - Anything with `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Boolean} True when the column is full
+ */
+export const isColumnFull = (board, col) =>
+  columnHeight(board, col) >= board.rows;
+
+/**
+ * The row a piece dropped into this column would come to rest on.
+ *
+ * This is what the hover preview and the drop animation both read, so it has
+ * to agree exactly with where `dropPiece` actually puts the piece — it is the
+ * same expression in both places, deliberately.
+ *
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Number|null} The landing row (0 = bottom), or null if the column
+ *   is full or is not on this board
+ */
+export const landingRow = (board, col) => {
+  if (!isColumnInRange(board, col)) return null;
+
+  const height = columnHeight(board, col);
+
+  return height < board.rows ? height : null;
+};
+
+/**
+ * Who occupies a cell.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @param {Number} row - Row index, 0 = BOTTOM
+ * @returns {String|Number|null} The slot resting there, or null when the cell
+ *   is empty or off the board
+ */
+export const cellAt = (board, col, row) => {
+  if (!isColumnInRange(board, col) || !isRowInRange(board, row)) return null;
+
+  return board.columns[col][row] ?? null;
+};
+
+/** How many cells the board has in total. */
+export const cellCount = ({ cols, rows }) => cols * rows;
+
+/** How many pieces have been played — which is also how many moves were made. */
+export const pieceCount = ({ columns }) =>
+  columns.reduce((total, column) => total + column.length, 0);
+
+/** Whether every cell is occupied. */
+export const isBoardFull = (board) =>
+  pieceCount(board) >= cellCount(board);
+
+/**
+ * The columns a piece can still be dropped into.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @returns {Number[]} Column indices, left to right
+ */
+export const openColumns = (board) =>
+  Array.from({ length: board.cols }, (unused, col) => col).filter(
+    (col) => !isColumnFull(board, col)
+  );

--- a/src/app/(pages)/games/connect-404/_lib/constants.js
+++ b/src/app/(pages)/games/connect-404/_lib/constants.js
@@ -1,0 +1,32 @@
+/**
+ * Connect 404 — shared constants.
+ *
+ * "Four in a row. Nothing found."
+ */
+
+// A standard Connect Four board: 7 columns wide, 6 rows tall, 42 cells.
+export const COLS = 7;
+export const ROWS = 6;
+
+// How many in a row wins. Named rather than inlined because the win scan reads
+// it four times and an off-by-one there is invisible until someone wins early.
+export const CONNECT = 4;
+
+// Connect Four is strictly two-handed — gravity and a 7x6 board only divide
+// two ways — so `slots` is always exactly this long.
+export const MIN_PLAYERS = 2;
+export const MAX_PLAYERS = 2;
+
+// Every reason a move can be rejected. `dropPiece` never throws for a bad
+// move — it returns the unchanged state (same reference) plus one of these.
+export const MoveError = Object.freeze({
+  Finished: "finished",
+  UnknownSlot: "unknown-slot",
+  NotYourTurn: "not-your-turn",
+  OutOfRange: "out-of-range",
+  ColumnFull: "column-full",
+  UnknownAction: "unknown-action",
+});
+
+// The action type the shared realtime core dispatches at `reducer`.
+export const DROP_PIECE = "DROP PIECE";

--- a/src/app/(pages)/games/connect-404/_lib/createState.js
+++ b/src/app/(pages)/games/connect-404/_lib/createState.js
@@ -1,0 +1,73 @@
+import { COLS, MAX_PLAYERS, MIN_PLAYERS, ROWS } from "./constants";
+
+const isSlot = (slot) =>
+  (typeof slot === "string" && slot.length > 0) || Number.isInteger(slot);
+
+/**
+ * A fresh board.
+ *
+ * Unlike `dropPiece`, this throws: a bad player list is a programming error in
+ * the lobby, not a move a player can make, and it must not produce a
+ * half-valid board the rest of the engine then has to defend against.
+ *
+ * @param {Object} options
+ * @param {(String|Number)[]} options.slots - The two player slots, in JOIN
+ *   ORDER. Turns rotate through this ARRAY — never through `Object.keys` of
+ *   anything, because a room's state is a MySQL JSON column and MySQL does not
+ *   preserve object key order. A turn order derived from key order passes every
+ *   local test and scrambles only online games.
+ * @param {String|Number} [options.first] - Who moves first. Defaults to
+ *   `slots[0]`; pass the previous winner so they open the next game.
+ * @returns {Object} A game state
+ */
+export const createState = ({ slots, first } = {}) => {
+  if (!Array.isArray(slots) || !slots.every(isSlot)) {
+    throw new Error(
+      "Connect 404: slots must be an array of non-empty strings or integers"
+    );
+  }
+
+  if (slots.length < MIN_PLAYERS || slots.length > MAX_PLAYERS) {
+    throw new Error(
+      `Connect 404: a game needs exactly ${MAX_PLAYERS} players, got ${slots.length}`
+    );
+  }
+
+  if (new Set(slots).size !== slots.length) {
+    throw new Error("Connect 404: slots must be unique");
+  }
+
+  if (first !== undefined && !slots.includes(first)) {
+    throw new Error("Connect 404: `first` must be one of the slots");
+  }
+
+  return {
+    cols: COLS,
+    rows: ROWS,
+    // Column-major stacks, bottom-first: `columns[c][0]` sits on the floor.
+    // See the coordinate convention at the top of `board.js`.
+    columns: Array.from({ length: COLS }, () => []),
+    // Join order, and the array turn rotation reads. Copied so the caller's
+    // roster and the board's running order cannot drift apart later.
+    slots: [...slots],
+    turn: first ?? slots[0],
+    lastMove: null,
+    winner: null,
+    winningLine: null,
+    draw: false,
+    finished: false,
+  };
+};
+
+/**
+ * The same two players, back at move one — the "play again" button.
+ *
+ * The winner opens the next game, which is the convention every one of these
+ * games uses. A draw has no winner to hand the first move to, so it goes back
+ * to join order.
+ *
+ * @param {Object} state - A finished (or abandoned) game state
+ * @returns {Object} A fresh game state with the same players
+ */
+export const resetState = ({ slots, winner }) =>
+  createState({ slots, first: winner ?? slots[0] });

--- a/src/app/(pages)/games/connect-404/_lib/dropPiece.js
+++ b/src/app/(pages)/games/connect-404/_lib/dropPiece.js
@@ -1,0 +1,84 @@
+import { MoveError } from "./constants";
+import { isBoardFull, isColumnFull, isColumnInRange, landingRow } from "./board";
+import { findWinningLine } from "./winningLine";
+
+const MESSAGES = {
+  [MoveError.Finished]: "The game is already over.",
+  [MoveError.UnknownSlot]: "You are not in this game.",
+  [MoveError.NotYourTurn]: "It is not your turn.",
+  [MoveError.OutOfRange]: "That column is not on this board.",
+  [MoveError.ColumnFull]: "That column is full.",
+  [MoveError.UnknownAction]: "Connect 404 does not know that action.",
+};
+
+// A rejected move leaves the state exactly as it was — SAME REFERENCE, so
+// callers can `if (result.state === state)` and skip a re-render.
+export const reject = (state, code) => ({
+  state,
+  error: { code, message: MESSAGES[code] },
+});
+
+// The next player in join order, wrapping. Reads the `slots` ARRAY; see the
+// note in `createState`.
+const nextTurn = ({ slots, turn }) =>
+  slots[(slots.indexOf(turn) + 1) % slots.length];
+
+/**
+ * Drop a piece into a column.
+ *
+ * Gravity is the whole game: a player picks a column, never a cell, and the
+ * piece lands on top of whatever is already there. `landingRow` reports that
+ * row for the hover preview, and this uses the same function to place it, so
+ * the ghost piece and the real one can never disagree.
+ *
+ * Pure and synchronous, so the server and every client can run it on the same
+ * state and land on the same board.
+ *
+ * @param {Object} state - The current game state
+ * @param {Number} col - The column to drop into, 0…cols - 1
+ * @param {String|Number} slot - The player attempting the move
+ * @returns {{state: Object, error?: {code: String, message: String}}} The next
+ *   state, or the untouched state and a reason it was rejected
+ */
+export const dropPiece = (state, col, slot) => {
+  const { columns, slots, turn } = state;
+
+  if (state.finished) return reject(state, MoveError.Finished);
+  if (!slots.includes(slot)) return reject(state, MoveError.UnknownSlot);
+  if (slot !== turn) return reject(state, MoveError.NotYourTurn);
+  if (!isColumnInRange(state, col)) return reject(state, MoveError.OutOfRange);
+  if (isColumnFull(state, col)) return reject(state, MoveError.ColumnFull);
+
+  const row = landingRow(state, col);
+
+  // Only the one column changes; the other six arrays are shared, which keeps
+  // a per-column memo in the renderer honest.
+  const nextColumns = [...columns];
+  nextColumns[col] = [...columns[col], slot];
+
+  const board = { ...state, columns: nextColumns };
+
+  // A win can only run through the piece that just landed, so that is the only
+  // cell worth scanning from.
+  const winningLine = findWinningLine(board, col, row);
+  const winner = winningLine ? slot : null;
+
+  // A full board with no line is a DRAW: a real, third outcome. It is not a
+  // loss for whoever filled the last cell, and it is not a win for anybody.
+  const draw = winner === null && isBoardFull(board);
+
+  return {
+    state: {
+      ...board,
+      // The mover stays on the clock once the game is over — there is no next
+      // turn to hand out, and a finished board reads better naming the player
+      // who ended it than the one who never got to reply.
+      turn: winner !== null || draw ? slot : nextTurn(state),
+      lastMove: { col, row, slot },
+      winner,
+      winningLine,
+      draw,
+      finished: winner !== null || draw,
+    },
+  };
+};

--- a/src/app/(pages)/games/connect-404/_lib/getResult.js
+++ b/src/app/(pages)/games/connect-404/_lib/getResult.js
@@ -1,0 +1,39 @@
+import { cellCount, pieceCount } from "./board";
+
+/**
+ * How the game stands, or how it ended.
+ *
+ * A DRAW is reported as a draw. A full board with no line is a real outcome —
+ * neither player lost it — so `winner` stays null and `draw` is true, and
+ * anything rendering a result must read `draw` before reaching for a name.
+ *
+ * The three end fields are decided by `dropPiece` at the moment the piece
+ * lands and stored on the state, because the online half persists that state
+ * and everybody has to agree on it. This reads them back and adds the counts a
+ * status line wants, rather than re-deciding the game.
+ *
+ * @param {Object} state - A game state, finished or not
+ * @returns {Object} winner, draw, winningLine, finished, turn, moves, cells
+ *   and remaining
+ */
+export const getResult = (state) => {
+  const { draw, finished, turn, winner, winningLine } = state;
+  const moves = pieceCount(state);
+  const cells = cellCount(state);
+
+  return {
+    // Null while the game is live, and null on a draw. `draw` is the field to
+    // read in the second case.
+    winner: winner ?? null,
+    draw: draw === true,
+    // The exact cells to highlight, in board order — four of them, or more on
+    // the rare run of five.
+    winningLine: winningLine ?? null,
+    finished: finished === true,
+    // Whose move it is; on a finished board, whoever played the last piece.
+    turn,
+    moves,
+    cells,
+    remaining: cells - moves,
+  };
+};

--- a/src/app/(pages)/games/connect-404/_lib/index.js
+++ b/src/app/(pages)/games/connect-404/_lib/index.js
@@ -1,0 +1,67 @@
+/**
+ * Connect 404 — the game engine.
+ *
+ * "Four in a row. Nothing found."
+ *
+ * Classic Connect Four. This module is the single source of truth for the
+ * rules: it is pure, synchronous and has no dependencies at all — not even
+ * lodash — so the server and every client run the identical code over the
+ * identical state and never disagree about whose turn it is or who won.
+ * Keep it that way; it has to run anywhere a game state does.
+ *
+ * The state:
+ *
+ *   {
+ *     cols: 7, rows: 6,
+ *     columns,        // 7 column stacks, columns[c][0] is the BOTTOM
+ *     slots,          // the two player slots, in join order — an ARRAY
+ *     turn,           // slot
+ *     lastMove,       // { col, row, slot } | null — row 0 is the bottom
+ *     winner,         // slot | null
+ *     winningLine,    // [[col, row], ...] | null — the cells to highlight
+ *     draw,           // bool
+ *     finished,       // bool — winner or draw
+ *   }
+ *
+ * ROW 0 IS THE BOTTOM, `col` grows rightward and `row` grows upward. The full
+ * coordinate convention every renderer and hit-test depends on is documented at
+ * the top of `board.js`. Read it there; do not re-derive it.
+ *
+ * `slots` is an array, and everything that iterates players reads that array.
+ * Room state round-trips through a MySQL JSON column and MySQL does not
+ * preserve object key order, so a turn order taken from `Object.keys` of
+ * anything would pass every local test and scramble only online games.
+ *
+ * A rejected move returns the state it was given, BY REFERENCE, alongside an
+ * error — never a throw and never a fresh object, so `result.state === state`
+ * is a valid "nothing happened, skip the render".
+ */
+
+export {
+  CONNECT,
+  COLS,
+  DROP_PIECE,
+  MAX_PLAYERS,
+  MIN_PLAYERS,
+  MoveError,
+  ROWS,
+} from "./constants";
+
+export { createState, resetState } from "./createState";
+export { dropPiece } from "./dropPiece";
+export { getResult } from "./getResult";
+export { reducer } from "./reducer";
+export { findWinningLine } from "./winningLine";
+
+export {
+  cellAt,
+  cellCount,
+  columnHeight,
+  isBoardFull,
+  isColumnFull,
+  isColumnInRange,
+  isRowInRange,
+  landingRow,
+  openColumns,
+  pieceCount,
+} from "./board";

--- a/src/app/(pages)/games/connect-404/_lib/reducer.js
+++ b/src/app/(pages)/games/connect-404/_lib/reducer.js
@@ -1,0 +1,36 @@
+import { DROP_PIECE, MoveError } from "./constants";
+import { dropPiece, reject } from "./dropPiece";
+
+/**
+ * The player a dispatch came from, as a slot.
+ *
+ * The shared realtime core hands its reducers a `player` OBJECT (it resolves
+ * the seat from the request's token), while the hotseat game has only a slot.
+ * Both are accepted here so neither caller has to remember which it holds; the
+ * engine itself only ever deals in slots.
+ */
+const slotOf = (player) =>
+  player !== null && typeof player === "object" ? player.slot : player;
+
+/**
+ * The per-game reducer the shared realtime core dispatches into: it takes the
+ * state, one action, and the player who sent it, and hands back the next state
+ * or a reason it was refused. Nothing here touches the network — the core owns
+ * transport, this owns the rules.
+ *
+ * @param {Object} state - The current game state
+ * @param {Object} action - `{ type: "DROP PIECE", col }`
+ * @param {String|Number|Object} player - The slot the action arrived from, or
+ *   the core's player object carrying it
+ * @returns {{state: Object, error?: {code: String, message: String}}} Next state
+ */
+export const reducer = (state, action, player) => {
+  switch (action?.type) {
+    case DROP_PIECE:
+      return dropPiece(state, action.col, slotOf(player));
+    default:
+      return reject(state, MoveError.UnknownAction);
+  }
+};
+
+export default reducer;

--- a/src/app/(pages)/games/connect-404/_lib/winningLine.js
+++ b/src/app/(pages)/games/connect-404/_lib/winningLine.js
@@ -1,0 +1,105 @@
+import { CONNECT } from "./constants";
+import { cellAt } from "./board";
+
+/**
+ * Connect 404 — win detection.
+ *
+ * The reference repo (`csalinas-dev/connect4`) never got here; its README
+ * still lists "determine if/when someone wins" as a TODO. So this is written
+ * from scratch, and it is the part of the engine worth being paranoid about.
+ *
+ * Coordinates are `[col, row]` with ROW 0 AT THE BOTTOM — see `board.js`.
+ *
+ * FOUR AXES, not eight. A line and its reverse are the same line, so each axis
+ * is stored once as a step `[dCol, dRow]` and walked in BOTH directions from
+ * the piece that was just played:
+ *
+ *        ↖ (-1,+1)   ↑ (0,+1)   ↗ (+1,+1)
+ *                  ╲    │    ╱
+ *        ← (-1,0) ──── ● ──── → (+1,0)
+ *                  ╱    │    ╲
+ *        ↙ (-1,-1)   ↓ (0,-1)   ↘ (+1,-1)
+ *
+ *   [1, 0]   horizontal   — ← ●
+ *   [0, 1]   vertical     — the stack the piece is sitting in
+ *   [1, 1]   diagonal ↗   — up and to the right ("/" on screen)
+ *   [1, -1]  diagonal ↘   — down and to the right ("\" on screen)
+ *
+ * Both diagonals. They are two distinct axes, and forgetting the second is the
+ * classic Connect Four bug: every test you happen to write passes and the
+ * board silently plays past a real win.
+ */
+const AXES = Object.freeze([
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1],
+]);
+
+/**
+ * How far the same slot continues from a cell in one direction.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Starting column (not counted)
+ * @param {Number} row - Starting row (not counted)
+ * @param {Number} dCol - Column step, -1 | 0 | 1
+ * @param {Number} dRow - Row step, -1 | 0 | 1
+ * @param {String|Number} slot - The slot to match
+ * @returns {Number} How many consecutive matching cells lie that way
+ */
+const runLength = (board, col, row, dCol, dRow, slot) => {
+  let count = 0;
+  let c = col + dCol;
+  let r = row + dRow;
+
+  // `cellAt` returns null off the board, so the edge stops the walk on its own
+  // and there is no separate bounds check to keep in step with this one.
+  while (cellAt(board, c, r) === slot) {
+    count += 1;
+    c += dCol;
+    r += dRow;
+  }
+
+  return count;
+};
+
+/**
+ * The winning line through a cell, if there is one.
+ *
+ * Only ever called with the cell that was just played: a win cannot appear
+ * anywhere a piece did not just land, so scanning all 42 cells after every
+ * move would be forty-one wasted answers.
+ *
+ * A run longer than four is possible — filling the gap in `● ● _ ● ●` makes
+ * five — and the whole run is returned, not an arbitrary four of it. A board
+ * highlighting only four of five in a row looks like a bug because it is one.
+ *
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column of the cell to test
+ * @param {Number} row - Row of the cell to test, 0 = BOTTOM
+ * @returns {Array<[Number, Number]>|null} The cells of the run in board order
+ *   — left to right, or bottom to top for a vertical — or null if no run of
+ *   four passes through the cell
+ */
+export const findWinningLine = (board, col, row) => {
+  const slot = cellAt(board, col, row);
+  if (slot === null) return null;
+
+  for (const [dCol, dRow] of AXES) {
+    const before = runLength(board, col, row, -dCol, -dRow, slot);
+    const after = runLength(board, col, row, dCol, dRow, slot);
+
+    if (before + 1 + after < CONNECT) continue;
+
+    // Walk from the far end of the run back along the axis, so the cells come
+    // out in board order — left to right, and bottom to top for a vertical.
+    const startCol = col - before * dCol;
+    const startRow = row - before * dRow;
+
+    return Array.from({ length: before + 1 + after }, (unused, step) => [
+      startCol + step * dCol,
+      startRow + step * dRow,
+    ]);
+  }
+
+  return null;
+};


### PR DESCRIPTION
The Connect 404 rules engine — pure logic, no UI, no network, no React. Closes #112.

Eight files under `src/app/(pages)/games/connect-404/_lib/`, structured after `edge-case/_lib`: `constants`, `board`, `winningLine`, `createState`, `dropPiece`, `getResult`, `reducer`, `index`.

## The coordinate convention

**Row 0 is the BOTTOM.** `col` grows rightward, `row` grows upward. The board is column-major — `columns[c][0]` rests on the floor and pieces are *pushed* on top, so gravity is `Array.prototype.push` and a floating piece is unrepresentable rather than merely illegal. A column's length is both its height and the row a new piece would land on, which is all `landingRow` is.

The full convention, with the ASCII diagram, is at the top of `_lib/board.js`. Read it there rather than re-deriving it — three renderers disagreeing about which end of a column is the floor is three different bugs. A cell is `[col, row]`, in that order, everywhere: `lastMove`, `winningLine`, `cellAt`.

Rendering top-down means walking rows **descending** (`for (let row = rows - 1; row >= 0; row -= 1)`). Flip the loop, never the stored data.

## The state (exactly the contract in #112)

```js
{
  cols: 7, rows: 6,
  columns,      // 7 stacks, columns[c][0] is the BOTTOM
  slots,        // the two player slots in join order — an ARRAY
  turn,         // slot
  lastMove,     // { col, row, slot } | null
  winner,       // slot | null
  winningLine,  // [[col, row], ...] | null
  draw,         // bool
  finished,     // bool — winner or draw
}
```

`slots` is an array and everything that iterates players reads that array. Room state round-trips through a MySQL JSON column and MySQL does not preserve object key order, so a turn order taken from `Object.keys` of anything passes every local test and scrambles only online games.

## Exports

| Signature | Notes |
| --- | --- |
| `createState({ slots, first })` | `first` defaults to `slots[0]`; throws on a bad roster (a lobby bug, not a move) |
| `resetState(state)` | Same players; the winner opens the next game, join order after a draw |
| `dropPiece(state, col, slot) => { state, error? }` | The only mutator |
| `reducer(state, action, player) => { state, error? }` | `{ type: "DROP PIECE", col }` |
| `landingRow(state, col) => Number\|null` | `null` when the column is full or off the board |
| `columnHeight(state, col)`, `isColumnFull(state, col)`, `cellAt(state, col, row)` | `cellAt` returns `null` off the board too |
| `getResult(state)` | `{ winner, draw, winningLine, finished, turn, moves, cells, remaining }` |
| `findWinningLine(board, col, row)` | The run through a cell, or `null` |
| `openColumns`, `pieceCount`, `isBoardFull`, `cellCount`, `isColumnInRange`, `isRowInRange` | |
| `COLS`, `ROWS`, `CONNECT`, `MIN_PLAYERS`, `MAX_PLAYERS`, `MoveError`, `DROP_PIECE` | |

## Rules

- Four in a row on **four axes** — horizontal, vertical and *both* diagonals — scanned from the piece that just landed, since a win cannot appear anywhere a piece did not.
- `winningLine` is the exact cells, in board order (left to right, bottom to top for a vertical).
- A full board with no line is a **draw**: `winner` stays null, `draw` is true. It is not a loss for whoever filled the last cell.
- Rejections carry a code and a message and return the state **by reference**, so `result.state === state` means "nothing happened, skip the render": `finished`, `unknown-slot`, `not-your-turn`, `out-of-range`, `column-full`, `unknown-action`.
- No dependencies, no clock, no randomness — the same code runs on the server and in the browser.

## Two judgement calls, stated rather than buried

1. **`winningLine` can be five cells.** Filling the gap in `● ● _ ● ●` makes a run of five, and the whole run is returned rather than an arbitrary four of it — a board highlighting four of five in a row looks like a bug because it is one. Treat it as "at least four", not "exactly four".
2. **`reducer` accepts either player shape.** The realtime core hands its reducers a player *object*; the hotseat game has only a slot. `slotOf` takes `player.slot` when handed an object and the value itself otherwise, so neither caller has to remember which it holds. The engine still only ever deals in slots.

## Verification

`npm run lint` and `npm run build` are clean. Rules proven with a throwaway Node harness (temp dir, not committed) that copies the engine out and rewrites its extensionless imports — including an **independently written** win scanner that re-derives the result from the board on every move and has to agree with the engine.

```
== 2. a win in each of the four directions ==
    1 | B B B . . . . |     3 | . . R . . . . |
    0 | R R R R . . . |     0 | . . R B . . . |   horizontal, vertical
    3 | . . . R . . . |     3 | . . . R . . . |
    2 | . . R R . . . |     2 | . . . R R . . |
    1 | . R R B . . . |     1 | . . . B R R . |   both diagonals
    0 | R B B B . . B |     0 | B . . B B B R |
    0 | R R R R R . . |                           a run of five, unclipped
== 3. a genuine draw on a completely full board ==
    5 | B B R B R R B |
    4 | R B R B R B R |
    3 | R B R R R B B |     42 pieces, no line anywhere,
    2 | R R B R B R B |     draw: true, winner: null
    1 | B R B R R B R |
    0 | B R B B R B B |
== 4. a win on the very last available cell ==
    5 | B R R B B B B |
    4 | R R B R R B R |
    3 | B R B R B R R |     the 42nd piece wins;
    2 | R B B R B R B |     a full board with a line is a WIN, not a draw
    1 | B B R B R B R |
    0 | R R B B R B R |
== 5. every rejection path, same state by reference ==
== 6. play again ==
== 7. 500 random full games ==
  500 games: 497 decided, 3 drawn, 10715 moves total

919349/919349 assertions passed, 0 failed
```

The draw and last-cell-win boards are found by backtracking search rather than hand-built, so they are genuinely reachable positions. Every move of the 500 random games asserts: piece count equals moves made, every column is a contiguous stack from the bottom (no floating pieces, no holes), `landingRow` predicted exactly where the piece landed, turns alternate, `finished` iff winner-or-draw, never a winner *and* a draw, never two winners, a reported win is really on the board and belongs to the last mover, the line is straight and contiguous, and `getResult` never disagrees with the state it read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
