### PR TITLE
feat(C404): animated board, hover preview, hotseat play

### DIFF
--- a/src/app/(pages)/games/connect-404/Connect404.jsx
+++ b/src/app/(pages)/games/connect-404/Connect404.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ContextProvider } from "./context";
+import Game from "./Game";
+
+/**
+ * Connect 404 — the page.
+ *
+ * One screen for now: the hotseat game, two players and one device. Online play
+ * and the mode picker in front of it are #114's, and they replace the body of
+ * this component rather than anything under it — `Game` and the board already
+ * take their state from a context that does not care who fills it.
+ */
+export const Connect404 = () => (
+  <ContextProvider>
+    <Game />
+  </ContextProvider>
+);
+
+export default Connect404;

--- a/src/app/(pages)/games/connect-404/Game.jsx
+++ b/src/app/(pages)/games/connect-404/Game.jsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useContext, useMemo } from "react";
+import styled from "@emotion/styled";
+
+import { getResult } from "./_lib";
+import { Board } from "./board";
+import { Announcer, Endgame, TurnBanner } from "./components";
+import { Context, dropPiece, newGame } from "./context";
+import { playerFor } from "./players";
+import { Toolbar } from "./Toolbar";
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  justify-content: flex-start;
+  padding: 3.5rem 1rem 1.5rem;
+  position: relative;
+  width: 100%;
+`;
+
+// One column, capped where a seven-wide board's columns are still a comfortable
+// thumb apart and a phone gets the whole thing edge to edge.
+const Stack = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  max-width: 30rem;
+  width: 100%;
+`;
+
+/**
+ * The game — the wiring between the store and the board.
+ *
+ * Everything the board needs is computed here and passed down, which is the
+ * whole point: this file does not know or care where its state came from. The
+ * hotseat provider fills the context from a `useReducer`; an online game (#114)
+ * fills the identical shape from a room. The only difference either makes is
+ * the pair of facts below — which slot this device plays, and whether it may
+ * move — and the board does not change by a line between them.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} [props.banner] - Rendered above the board. An online
+ *   game puts its room strip here.
+ */
+export default function Game({ banner }) {
+  const { state, dispatch, online } = useContext(Context);
+  const { game, players } = state;
+
+  const result = useMemo(() => getResult(game), [game]);
+
+  // Hotseat: the device belongs to whoever is up. Online: to the seat this
+  // browser holds — resolved by the server from its token — and only while the
+  // clock is on that seat. A spectator has no seat, so `youSlot` is null and
+  // nothing on the board is live.
+  const youSlot = online ? online.youSlot : game.turn;
+  const interactive = online
+    ? youSlot !== null && youSlot === game.turn && !game.finished
+    : !game.finished;
+
+  // Whose name the banner says is on the clock. NOT `youSlot`: on one device
+  // they are the same player and online they are usually not, and a banner that
+  // reads "Blue to move" while Red is thinking is worse than no banner.
+  const mover = playerFor(players, game.turn);
+
+  const onDrop = useCallback(
+    (col) => dispatch(dropPiece(col, youSlot)),
+    [dispatch, youSlot]
+  );
+
+  const onPlayAgain = useCallback(() => dispatch(newGame()), [dispatch]);
+
+  return (
+    <Container>
+      <Toolbar
+        cells={result.cells}
+        moves={result.moves}
+        /* Online there is no mid-game restart — a shared board is not one
+           player's to wipe — so the rematch lives in the endgame panel and
+           this button is simply absent. */
+        onRestart={online ? null : onPlayAgain}
+      />
+
+      <Stack>
+        {banner}
+
+        <TurnBanner game={game} player={mover} />
+
+        <Board
+          game={game}
+          interactive={interactive}
+          onDrop={onDrop}
+          players={players}
+          youSlot={youSlot}
+        />
+
+        {result.finished && (
+          <Endgame
+            game={game}
+            onPlayAgain={onPlayAgain}
+            winner={
+              result.winner === null ? null : playerFor(players, result.winner)
+            }
+          />
+        )}
+      </Stack>
+
+      <Announcer game={game} players={players} />
+    </Container>
+  );
+}

--- a/src/app/(pages)/games/connect-404/Toolbar.jsx
+++ b/src/app/(pages)/games/connect-404/Toolbar.jsx
@@ -1,0 +1,87 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  display: flex;
+  flex-flow: row nowrap;
+  font-size: 1rem;
+  gap: 0.5rem;
+  left: 0;
+  line-height: 1rem;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  @media (max-width: 600px) {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+  }
+`;
+
+// The game's name is the longest thing here and the page title already says it,
+// so it is the first thing to go when the toolbar runs out of room.
+const Name = styled.div`
+  flex: 1 1 auto;
+  white-space: nowrap;
+
+  @media (max-width: 480px) {
+    display: none;
+  }
+`;
+
+const Progress = styled.div`
+  color: var(--absentForeground);
+  flex: 1 1 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+`;
+
+const Action = styled.button`
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  color: var(--component);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: inherit;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
+  white-space: nowrap;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * The strip across the top of the board.
+ *
+ * The action is optional, and a null handler means the button is not there at
+ * all rather than there and inert. Online there is no "restart" mid-game: a
+ * shared board is not one player's to wipe.
+ */
+export const Toolbar = ({ cells, moves, onRestart }) => (
+  <Container>
+    <Name>Connect 404</Name>
+    <Progress>
+      {moves} / {cells} pieces
+    </Progress>
+    {onRestart && (
+      <Action onClick={onRestart} type="button">
+        {/* The Font Awesome kit replaces this <i> with an <svg> after mount, so
+            it lives in a wrapper React owns — otherwise unmounting a button
+            React no longer recognises throws. */}
+        <span>
+          <i className="fa-solid fa-rotate-left" />
+        </span>{" "}
+        Restart
+      </Action>
+    )}
+  </Container>
+);

--- a/src/app/(pages)/games/connect-404/board/Board.jsx
+++ b/src/app/(pages)/games/connect-404/board/Board.jsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { range } from "lodash";
+import styled from "@emotion/styled";
+
+import { landingRow, pieceCount } from "../_lib";
+import { playerFor } from "../players";
+import { useColumnNavigation } from "../hooks";
+import { reload } from "./animations";
+import { Column } from "./Column";
+import { Piece } from "./Piece";
+import { VisuallyHidden } from "../components/VisuallyHidden";
+
+// How long a refusal stays on screen. Long enough to read, short enough that a
+// player who meant to press the column next door is not waiting on it. Cleared
+// on a timer rather than on `animationend`, because under reduced motion the
+// shake never runs and there is no such event to wait for.
+const REFUSAL_MS = 900;
+
+const Frame = styled.div`
+  /* The panel's inset. The chute above it takes the same one so the piece
+     waiting there lines up with the column it is waiting over. */
+  --pad: 0.45rem;
+
+  margin: 0 auto;
+  max-width: 30rem;
+  width: 100%;
+`;
+
+const Chute = styled.div`
+  padding: 0 var(--pad);
+`;
+
+// Exactly one cell tall, and the same width as the columns underneath, so a
+// piece in it is already in the position the fall starts from.
+const Track = styled.div`
+  aspect-ratio: var(--cols) / 1;
+  position: relative;
+  width: 100%;
+`;
+
+// Carries the piece across the board. Transform only, so following the cursor
+// costs nothing but a composite.
+const Rail = styled.div`
+  aspect-ratio: 1 / 1;
+  left: 0;
+  position: absolute;
+  top: 0;
+  transform: translateX(calc(var(--col) * 100%));
+  transition: transform 150ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  width: calc(100% / var(--cols));
+
+  &.blocked {
+    opacity: 0.3;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+// The reload sits inside the rail rather than on it: both want the `transform`
+// property, and the piece has to be able to arrive and slide across at once.
+const Loaded = styled.div`
+  animation: ${reload} 200ms ease-out both;
+  height: 100%;
+  width: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;
+
+// Nothing here may clip: a falling piece spends most of its animation above the
+// panel, in the chute's airspace and sometimes above that.
+const Surface = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Panel = styled.div`
+  background-color: var(--absentBackground);
+  border: 1px solid var(--selectionBackground);
+  border-radius: 0.75rem;
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  padding: var(--pad);
+  /* The board owns the gestures that land on it — a drag across the columns
+     must not scroll the page out from under the player. */
+  touch-action: manipulation;
+  width: 100%;
+`;
+
+/**
+ * The Connect 404 board.
+ *
+ * This component owns NO game state. It is handed a state, a cast of players,
+ * which slot this device plays and whether that slot may move right now; it
+ * hands back the column that was chosen. Everything it keeps to itself is
+ * presentation — what the cursor is over, what has focus, which column has just
+ * refused a piece.
+ *
+ * That split is deliberate and load-bearing: the hotseat game passes
+ * `youSlot = game.turn`, and an online room (#114) passes the slot that device
+ * joined as and sends `onDrop` over the wire. A spectator passes `interactive
+ * = false` and a null slot. None of them needs the board to change.
+ *
+ * The animation is the feature, so it is worth saying what it does *not* do:
+ * it does not decide anything. A piece is rendered in the cell the engine put
+ * it in before its first frame runs, and every frame of the fall is an offset
+ * from that cell ending at zero. If the animation were dropped entirely — as it
+ * is under `prefers-reduced-motion` — the board would be in the same place.
+ *
+ * @param {Object} props
+ * @param {Object} props.game - An engine state (see `_lib`)
+ * @param {Object[]} props.players - Player descriptors in join order
+ * @param {?(String|Number)} [props.youSlot] - The slot this device plays, if any
+ * @param {Boolean} props.interactive - Whether this device may move right now
+ * @param {Function} props.onDrop - `(col) => void`
+ * @param {React.ReactNode} [props.overlay] - Rendered over the panel, sized to
+ *   it. A "waiting for the other player" curtain (#114) belongs here. The
+ *   endgame deliberately does not: the four winning pieces are the point of
+ *   winning, and covering them to say so would be a strange thing to do.
+ */
+export const Board = ({
+  game,
+  interactive,
+  onDrop,
+  overlay,
+  players,
+  youSlot,
+}) => {
+  // Hover (mouse) and focus (keyboard) are the same idea — "the column I am
+  // about to commit to" — so they feed one preview. Hover wins when both are
+  // live, because the hand is the thing that just moved.
+  const [hovered, setHovered] = useState(null);
+  const [focused, setFocused] = useState(null);
+
+  // A column that has just been asked for a piece it cannot take. `nonce` is
+  // what makes the second refusal look like a refusal too.
+  const [refused, setRefused] = useState(null);
+  const nonce = useRef(0);
+
+  const onActivate = useCallback(
+    (col) => {
+      if (!interactive) return;
+
+      // Stopped at the tap rather than sent and rejected. The engine refuses a
+      // full column too and is still the authority — but online this would be a
+      // round trip whose only possible answer is the one already on screen.
+      if (landingRow(game, col) === null) {
+        nonce.current += 1;
+        setRefused({ col, id: nonce.current });
+        return;
+      }
+
+      setRefused(null);
+      onDrop(col);
+    },
+    [game, interactive, onDrop]
+  );
+
+  const { activeColumn: tabColumn, onKeyDown, register } = useColumnNavigation(
+    game.cols,
+    onActivate
+  );
+
+  useEffect(() => {
+    if (!refused) return undefined;
+
+    const timer = setTimeout(() => setRefused(null), REFUSAL_MS);
+    return () => clearTimeout(timer);
+  }, [refused]);
+
+  const onHover = useCallback((col) => setHovered(col), []);
+  const onFocus = useCallback((col) => setFocused(col), []);
+  const onBlur = useCallback(() => setFocused(null), []);
+
+  const you = useMemo(
+    () => (youSlot === null || youSlot === undefined ? null : playerFor(players, youSlot)),
+    [players, youSlot]
+  );
+
+  // Every move remounts the piece in the chute, which is what replays its
+  // arrival. Counting pieces rather than watching `lastMove` because a new game
+  // has to reload it too, and a new game has no last move.
+  const played = useMemo(() => pieceCount(game), [game]);
+
+  const previewColumn = hovered ?? focused;
+  const previewing = interactive && you !== null && previewColumn !== null;
+  const previewBlocked =
+    previewing && landingRow(game, previewColumn) === null;
+
+  return (
+    <Frame style={{ "--cols": game.cols }}>
+      {/* Where the piece waits, and where the fall starts from. Decorative: the
+          column buttons underneath say the same thing in words. */}
+      <Chute aria-hidden="true">
+        <Track>
+          {previewing && (
+            <Rail
+              className={previewBlocked ? "blocked" : undefined}
+              style={{ "--col": previewColumn }}
+            >
+              <Loaded key={played}>
+                <Piece player={you} />
+              </Loaded>
+            </Rail>
+          )}
+        </Track>
+      </Chute>
+
+      <Surface>
+        <Panel
+          aria-label={`Connect 404 board, ${game.cols} columns by ${game.rows} rows. Use the left and right arrow keys to choose a column and enter to drop a piece.`}
+          role="group"
+        >
+          {range(game.cols).map((col) => (
+            <Column
+              active={previewColumn === col}
+              col={col}
+              game={game}
+              interactive={interactive}
+              key={col}
+              landingRow={landingRow(game, col)}
+              onActivate={onActivate}
+              onBlur={onBlur}
+              onFocus={onFocus}
+              onHover={onHover}
+              onKeyDown={onKeyDown}
+              players={players}
+              refusedNonce={refused?.col === col ? refused.id : null}
+              register={register(col)}
+              tabIndex={tabColumn === col ? 0 : -1}
+              you={you}
+            />
+          ))}
+        </Panel>
+
+        {overlay}
+      </Surface>
+
+      {/* Assertive, and its own region: a refusal interrupts, which is the one
+          thing the running commentary must never do. */}
+      <VisuallyHidden role="alert">
+        {refused ? `Column ${refused.col + 1} is full.` : ""}
+      </VisuallyHidden>
+    </Frame>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Cell.jsx
+++ b/src/app/(pages)/games/connect-404/board/Cell.jsx
@@ -1,0 +1,129 @@
+import styled from "@emotion/styled";
+
+import { fall, pop } from "./animations";
+import { Piece } from "./Piece";
+
+// One square of the grid: an empty socket punched out of the panel, and — if
+// somebody has played here — a piece sitting in it.
+//
+// No margin, no gap, no border. The pitch between cells has to be exactly one
+// cell height or the drop animation, which counts in cells, lands short. The
+// space between the sockets comes from the sockets being smaller than the
+// cells, not from anything between them.
+const Container = styled.div`
+  aspect-ratio: 1 / 1;
+  position: relative;
+  width: 100%;
+
+  /* The hole. */
+  &::before {
+    background-color: var(--background);
+    border-radius: 50%;
+    box-shadow: inset 0 0.08rem 0.22rem rgba(0, 0, 0, 0.55);
+    content: "";
+    inset: 7%;
+    position: absolute;
+  }
+
+  /* Exactly one cell tall, which is what makes translateY(-100%) mean "one row
+     up" — the piece inside it is smaller, and cannot be measured in rows. */
+  .slot {
+    inset: 0;
+    position: absolute;
+  }
+
+  &.landing .slot {
+    /* Farther is longer, the way a longer fall takes longer. The --drop
+       variable is unitless so it can be multiplied by a time here and by a
+       length in the keyframes. */
+    animation: ${fall} calc(150ms + var(--drop) * 52ms) both;
+  }
+
+  /* Part of the four. The ring is permanent and the swell is a one-off, so the
+     line stays marked long after the animation has finished — and a player who
+     looks up late has still missed nothing. */
+  &.winning {
+    z-index: 2;
+
+    .disc {
+      filter: drop-shadow(0 0 0.4rem var(--slot));
+      animation: ${pop} 620ms ease-out var(--delay) both;
+    }
+
+    circle {
+      stroke: var(--foreground);
+      stroke-width: 1.1;
+    }
+  }
+
+  /* Everything that is not part of the winning line steps back so the line can
+     step forward. Never below the point of being readable. */
+  &.dimmed .disc {
+    opacity: 0.4;
+  }
+
+  .disc {
+    height: 100%;
+    transition: opacity 400ms ease-out 500ms;
+    width: 100%;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.landing .slot,
+    &.winning .disc {
+      animation: none;
+    }
+
+    .disc {
+      transition: none;
+    }
+  }
+`;
+
+/**
+ * A cell.
+ *
+ * Everything it is told comes from the engine. It does not know the rules, it
+ * does not know whose turn it is, and — the important one — it does not decide
+ * where a piece stops. `drop` is the distance from the chute to the row the
+ * engine picked, in cells, and the animation only ever runs *up* from there.
+ *
+ * @param {Object} props
+ * @param {?Object} props.player - Whoever is in this cell, or null
+ * @param {Boolean} props.landing - This is the piece that has just been played
+ * @param {Number} props.drop - How many cells above its cell the piece starts
+ * @param {Number} props.winIndex - Its place along the winning line, or -1
+ * @param {Boolean} props.dimmed - The game is won and this is not part of it
+ */
+export const Cell = ({ dimmed, drop, landing, player, winIndex }) => {
+  const winning = winIndex >= 0;
+
+  const className = [
+    landing && "landing",
+    winning && "winning",
+    dimmed && "dimmed",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Container
+      className={className || undefined}
+      style={{
+        "--drop": drop,
+        // Staggered along the line, and held back long enough that the piece
+        // that completed it has landed before its own cell swells.
+        "--delay": winning ? `${240 + winIndex * 110}ms` : undefined,
+        "--slot": player?.color,
+      }}
+    >
+      {player && (
+        <div className="slot">
+          <div className="disc">
+            <Piece player={player} />
+          </div>
+        </div>
+      )}
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Column.jsx
+++ b/src/app/(pages)/games/connect-404/board/Column.jsx
@@ -1,0 +1,200 @@
+import { range } from "lodash";
+import styled from "@emotion/styled";
+
+import { cellAt } from "../_lib";
+import { playerFor } from "../players";
+import { refuse } from "./animations";
+import { Cell } from "./Cell";
+
+// A whole column is one control. That is how the game is played — you choose a
+// column, not a square — and it also happens to give a phone a tap target six
+// cells tall, which no individual cell would.
+const Container = styled.button`
+  background-color: transparent;
+  border: none;
+  border-radius: 0.5rem;
+  color: inherit;
+  cursor: default;
+  display: block;
+  font: inherit;
+  padding: 0;
+  position: relative;
+  width: 100%;
+
+  &.open {
+    cursor: pointer;
+  }
+
+  &.full {
+    cursor: not-allowed;
+  }
+
+  /* The column under the cursor or the keyboard. Faint, because it is behind
+     six sockets and the piece hovering over it says the same thing louder. */
+  &.active::after {
+    background-color: var(--selectionBackground);
+    border-radius: 0.4rem;
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+// The thing that actually shakes when a full column is asked for another piece.
+// Separate from the button so the refusal never moves the focus ring, and so it
+// can be remounted to replay — which the button, holding focus, must not be.
+const Stack = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  width: 100%;
+
+  &.refused {
+    animation: ${refuse} 380ms ease-in-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.refused {
+      animation: none;
+    }
+  }
+`;
+
+/**
+ * What is in a column, bottom first.
+ *
+ * Bottom first because that is the order the pieces arrived in and the order
+ * the labels count rows in — a column read top-down would be describing a
+ * board nobody is playing on.
+ *
+ * @returns {String} "empty", or "3 of 6 filled, from the bottom: Red, Blue, Red"
+ */
+const describeContents = (game, players, col) => {
+  const height = game.columns[col].length;
+  if (height === 0) return "empty";
+
+  const names = range(height).map(
+    (row) => playerFor(players, cellAt(game, col, row)).name
+  );
+
+  // A full column says so first and counts afterwards. "6 of 6 filled" is the
+  // same fact arrived at by arithmetic, and it should not be the first thing a
+  // player has to do to find out they cannot play there.
+  const state =
+    height >= game.rows ? "full" : `${height} of ${game.rows} filled`;
+
+  return `${state}, from the bottom: ${names.join(", ")}`;
+};
+
+/**
+ * One column of the board, and the control that drops a piece into it.
+ *
+ * @param {Object} props
+ * @param {Number} props.col - 0-based column
+ * @param {Object} props.game - An engine state
+ * @param {Object[]} props.players - Player descriptors
+ * @param {Boolean} props.active - The cursor or the keyboard is on this column
+ * @param {Boolean} props.interactive - This device may drop a piece right now
+ * @param {?Number} props.landingRow - Where a piece would land, null if full
+ * @param {?Object} props.you - Whose piece would be dropped, if anyone's
+ * @param {?Number} props.refusedNonce - Set, and different each time, while this
+ *   column is refusing a drop
+ * @param {Function} props.onActivate - `(col) => void`
+ * @param {Function} props.onHover - `(col | null) => void`
+ * @param {Function} props.onFocus - `(col) => void`
+ * @param {Function} props.onBlur - `() => void`
+ * @param {Function} props.onKeyDown - `(event, col) => void`
+ * @param {Function} props.register - Ref callback for the roving tab stop
+ * @param {Number} props.tabIndex - 0 for the one column that owns the tab stop
+ */
+export const Column = ({
+  active,
+  col,
+  game,
+  interactive,
+  landingRow,
+  onActivate,
+  onBlur,
+  onFocus,
+  onHover,
+  onKeyDown,
+  players,
+  refusedNonce,
+  register,
+  tabIndex,
+  you,
+}) => {
+  const full = landingRow === null;
+  const open = interactive && !full;
+
+  // What the column is, then what pressing it would do. The second half is
+  // absent for a spectator and for the player who is not on the clock, because
+  // for them pressing it does nothing.
+  let label = `Column ${col + 1}, ${describeContents(game, players, col)}`;
+  if (open && you) {
+    label += `. Drop ${you.name} here, landing in row ${landingRow + 1} from the bottom`;
+  }
+
+  const className = [open && "open", interactive && full && "full", active && "active"]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Container
+      aria-disabled={!open}
+      aria-label={label}
+      className={className || undefined}
+      onBlur={onBlur}
+      onClick={() => onActivate(col)}
+      onFocus={() => onFocus(col)}
+      onKeyDown={(event) => onKeyDown(event, col)}
+      onPointerEnter={() => onHover(col)}
+      onPointerLeave={() => onHover(null)}
+      ref={register}
+      tabIndex={tabIndex}
+      type="button"
+    >
+      {/* Remounted on every refusal so the shake replays on the second attempt
+          as well as the first. Keyed on "idle" the rest of the time, so nothing
+          else in the column is ever torn down. */}
+      <Stack
+        className={refusedNonce ? "refused" : undefined}
+        key={refusedNonce ?? "idle"}
+      >
+        {/* Top-down, because that is the order the rows appear on screen —
+            and the engine counts from the bottom, so this is the one place the
+            two conventions have to meet. Row 0 is the LAST cell rendered. */}
+        {range(game.rows - 1, -1, -1).map((row) => {
+          const slot = cellAt(game, col, row);
+          // Every cell the engine names, however many that is. Filling the gap
+          // in ● ● _ ● ● makes a genuine run of five and the engine returns all
+          // of it; slicing to four would leave a piece of the winning line
+          // looking like it lost.
+          const winIndex =
+            game.winningLine?.findIndex(
+              ([wc, wr]) => wc === col && wr === row
+            ) ?? -1;
+
+          return (
+            <Cell
+              dimmed={game.winner !== null && winIndex < 0}
+              /* From the chute, one cell above the top row, down to here. */
+              drop={game.rows - row}
+              key={row}
+              landing={
+                game.lastMove?.col === col && game.lastMove?.row === row
+              }
+              player={slot === null ? null : playerFor(players, slot)}
+              winIndex={winIndex}
+            />
+          );
+        })}
+      </Stack>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Piece.jsx
+++ b/src/app/(pages)/games/connect-404/board/Piece.jsx
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+// The disc, and the initial stamped on it.
+//
+// SVG rather than a text node so the letter scales with the board instead of
+// with the root font size: the same markup has to look right in a 4rem cell on
+// a desktop and a 45px one on a phone, and a `font-size` that works at one end
+// is wrong at the other.
+//
+// The element fills its cell and the circle is inset inside it, rather than the
+// element being the circle. That is deliberate: the drop animation moves this
+// element by whole cells, so its height has to *be* one cell.
+const Glyph = styled.svg`
+  display: block;
+  height: 100%;
+  width: 100%;
+
+  text {
+    fill: var(--background);
+    font-family: inherit;
+    font-weight: 700;
+  }
+`;
+
+// Cell units. The board's empty sockets are cut to the same radius, so a piece
+// sits in one exactly.
+export const PIECE_RADIUS = 8.6;
+
+/**
+ * A player's piece.
+ *
+ * The initial is not decoration. Red and blue is a kinder pair than most, but
+ * the site's rule is that colour never carries a fact on its own, and "which of
+ * these is mine" is the only fact this board has.
+ *
+ * @param {Object} props
+ * @param {Object} props.player - A player descriptor from `players.js`
+ */
+export const Piece = ({ player }) => (
+  <Glyph aria-hidden="true" viewBox="0 0 20 20">
+    <circle
+      cx="10"
+      cy="10"
+      fill={player.color}
+      r={PIECE_RADIUS}
+      /* A rim rather than a shadow: it survives the piece being drawn over an
+         empty socket mid-fall, which a drop shadow does not. */
+      stroke="rgba(0, 0, 0, 0.32)"
+      strokeWidth="0.7"
+    />
+    <text
+      dominantBaseline="central"
+      fontSize="9"
+      textAnchor="middle"
+      x="10"
+      y="10.4"
+    >
+      {player.initial}
+    </text>
+  </Glyph>
+);

--- a/src/app/(pages)/games/connect-404/board/animations.js
+++ b/src/app/(pages)/games/connect-404/board/animations.js
@@ -1,0 +1,71 @@
+import { keyframes } from "@emotion/react";
+
+/**
+ * The fall.
+ *
+ * The piece is already in its final cell in the DOM before a single frame of
+ * this runs — every keyframe is an *offset* from where the engine put it, and
+ * the last one is zero. That is the whole trick, and it is the reason the
+ * animation cannot get the landing wrong: there is no frame in which the piece
+ * is anywhere but its own cell, only frames in which it is drawn above it.
+ *
+ * `--drop` is how many cells up the piece starts, which `Cell` derives from the
+ * engine's landing row. Cells are square and stacked with no gap between them,
+ * so one cell is exactly 100% of this element's height and the piece leaves
+ * from the chute it was previewed in.
+ *
+ * The first segment eases in like something falling — a quadratic, near enough —
+ * and the two after it are the bounce it arrives with.
+ */
+export const fall = keyframes`
+  0% {
+    transform: translateY(calc(var(--drop) * -100%));
+    animation-timing-function: cubic-bezier(0.45, 0, 0.75, 0.45);
+  }
+  68% {
+    transform: translateY(0);
+    animation-timing-function: cubic-bezier(0.3, 0, 0.35, 1);
+  }
+  81% {
+    transform: translateY(-9%);
+    animation-timing-function: cubic-bezier(0.6, 0, 0.75, 0.5);
+  }
+  91% {
+    transform: translateY(0);
+    animation-timing-function: ease-out;
+  }
+  96% {
+    transform: translateY(-2.5%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+`;
+
+// Each winning piece swells once, staggered along the line, so the four read as
+// a line being drawn rather than four things lighting up at once. The ring that
+// marks them is permanent CSS underneath — this only draws the eye to it, and a
+// player who arrives after it has finished has lost nothing.
+export const pop = keyframes`
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.22); }
+  100% { transform: scale(1); }
+`;
+
+// A column that will not take another piece. Short, sharp and lateral: it reads
+// as "no" without looking like part of the game.
+export const refuse = keyframes`
+  0%, 100% { transform: translateX(0); }
+  15%      { transform: translateX(-7%); }
+  35%      { transform: translateX(6%); }
+  55%      { transform: translateX(-4%); }
+  75%      { transform: translateX(2.5%); }
+`;
+
+// The next piece arriving in the chute. It replaces one that has just fallen
+// out of it, and without this they overlap for a frame and read as two pieces
+// in one place.
+export const reload = keyframes`
+  from { opacity: 0; transform: scale(0.55); }
+  to   { opacity: 1; transform: scale(1); }
+`;

--- a/src/app/(pages)/games/connect-404/board/index.js
+++ b/src/app/(pages)/games/connect-404/board/index.js
@@ -1,0 +1,2 @@
+export * from "./Board";
+export * from "./Piece";

--- a/src/app/(pages)/games/connect-404/components/Announcer.jsx
+++ b/src/app/(pages)/games/connect-404/components/Announcer.jsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import { playerFor } from "../players";
+import { VisuallyHidden } from "./VisuallyHidden";
+
+const list = (items) =>
+  items.length < 2
+    ? items.join("")
+    : `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+
+// Rows are counted from the bottom everywhere a player can hear them, because
+// that is the end of a column a piece actually arrives at. The column labels
+// say "from the bottom" too.
+const cellName = ([col, row]) => `column ${col + 1} row ${row + 1}`;
+
+/**
+ * The running commentary a screen reader hears.
+ *
+ * A player who cannot see the board needs the two facts a sighted player reads
+ * off it instantly: what just landed, and who is up. Where a piece landed is
+ * the whole of the first — a column tells you nothing on its own, because
+ * gravity, not the player, chose the row.
+ *
+ * The winning line is named cell by cell rather than announced as "four in a
+ * row", because "where" is the interesting part and it is the one thing the
+ * highlight on screen conveys that words otherwise would not. It is however
+ * many cells the engine found, which is occasionally five.
+ */
+export const Announcer = ({ game, players }) => {
+  const message = useMemo(() => {
+    const upNext = playerFor(players, game.turn);
+
+    if (!game.lastMove) {
+      return `New game. ${game.cols} columns, ${game.rows} rows. ${upNext.name} to move.`;
+    }
+
+    const { col, row, slot } = game.lastMove;
+    const mover = playerFor(players, slot);
+
+    let sentence = `${mover.name} dropped into column ${col + 1}, landing in row ${
+      row + 1
+    } from the bottom.`;
+
+    if (game.winner !== null) {
+      const line = (game.winningLine ?? []).map(cellName);
+      return `${sentence} ${mover.name} wins with ${line.length} in a row: ${list(
+        line
+      )}.`;
+    }
+
+    if (game.draw) {
+      return `${sentence} The board is full. The game is a draw.`;
+    }
+
+    return `${sentence} ${upNext.name} to move.`;
+  }, [game, players]);
+
+  return (
+    <VisuallyHidden aria-atomic="true" aria-live="polite" role="status">
+      {message}
+    </VisuallyHidden>
+  );
+};

--- a/src/app/(pages)/games/connect-404/components/Endgame.jsx
+++ b/src/app/(pages)/games/connect-404/components/Endgame.jsx
@@ -1,0 +1,112 @@
+"use client";
+
+import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+
+const reveal = keyframes`
+  from { opacity: 0; transform: translateY(-0.3rem); }
+  to   { opacity: 1; transform: translateY(0); }
+`;
+
+// Under the board, not over it. The four highlighted pieces are what winning
+// looks like, and a panel that covered them to announce the win would be
+// announcing something the player can no longer see.
+const Panel = styled.div`
+  align-items: center;
+  animation: ${reveal} 300ms ease-out 620ms both;
+  background-color: var(--absentBackground);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.75rem 0.9rem;
+  width: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;
+
+const Verdict = styled.div`
+  /* Shrinks rather than pushing the button onto a line of its own. It wraps
+     eventually, on a narrow phone, which is the width it should wrap at. */
+  flex: 1 1 10rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.5rem;
+  min-width: 0;
+
+  .slot {
+    color: var(--slot);
+  }
+
+  small {
+    color: var(--absentForeground);
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 400;
+    line-height: 1.05rem;
+  }
+`;
+
+const Again = styled.button`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--component);
+  border-radius: 0.4rem;
+  color: var(--component);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 1rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 1.25rem;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * The end of the game, and the rematch.
+ *
+ * Held back until the winning line has finished lighting up — the highlight is
+ * the announcement, and a panel sliding in over the top of it is an
+ * interruption. It is a delay on an entrance animation only: the result is in
+ * the DOM and in the live region from the first frame, so nothing waits on it.
+ *
+ * A draw is reported as a draw. Forty-two pieces and no line is a real outcome
+ * and neither player lost it, so nothing here reaches for a name.
+ *
+ * @param {Object} props
+ * @param {Object} props.game - The finished engine state
+ * @param {Object} props.winner - The winning player descriptor, on a win
+ * @param {Function} [props.onPlayAgain] - Omitted for a spectator, who gets the
+ *   result and no controls.
+ */
+export const Endgame = ({ game, onPlayAgain, winner }) => (
+  <Panel>
+    <Verdict style={{ "--slot": winner?.color }}>
+      {game.draw ? (
+        <>
+          Draw
+          <small>The board is full and there is no line.</small>
+        </>
+      ) : (
+        <>
+          <span className="slot">{winner.name}</span> wins
+          <small>
+            {game.winningLine.length} in a row. {winner.name} opens the next game.
+          </small>
+        </>
+      )}
+    </Verdict>
+
+    {onPlayAgain && (
+      <Again autoFocus onClick={onPlayAgain} type="button">
+        Play again
+      </Again>
+    )}
+  </Panel>
+);

--- a/src/app/(pages)/games/connect-404/components/TurnBanner.jsx
+++ b/src/app/(pages)/games/connect-404/components/TurnBanner.jsx
@@ -1,0 +1,102 @@
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  /* The colour bar. A strip of solid slot colour running the height of the
+     banner is the answer to "which one am I?" from across a table — a small
+     swatch next to a name is not. */
+  border-left: 0.4rem solid var(--slot);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0.6rem 0.9rem;
+  width: 100%;
+
+  &.draw {
+    border-left-color: var(--absentForeground);
+  }
+`;
+
+const Chip = styled.span`
+  align-items: center;
+  background-color: var(--slot);
+  border-radius: 50%;
+  color: var(--background);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+  font-weight: 700;
+  height: 2.1rem;
+  justify-content: center;
+  width: 2.1rem;
+`;
+
+const Copy = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.15rem;
+  min-width: 0;
+`;
+
+const Headline = styled.div`
+  color: var(--slot);
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.4rem;
+`;
+
+const Hint = styled.small`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  line-height: 1.05rem;
+`;
+
+/**
+ * Whose turn it is, in their colour, at the size the question deserves.
+ *
+ * Rendered after the game as well as during it, because the engine leaves
+ * `turn` with the player who ended it on purpose — the board must never be left
+ * without a valid slot, and therefore never without a colour.
+ *
+ * A draw is the exception and is said plainly. Nobody won; the banner does not
+ * get to imply otherwise by leaving the last mover's name up in their colour.
+ *
+ * @param {Object} props
+ * @param {Object} props.player - The player on the clock (or who ended it)
+ * @param {Object} props.game - The engine state
+ * @param {String} [props.hint] - Overrides the sub-line. An online room puts
+ *   "waiting for Alex…" here.
+ */
+export const TurnBanner = ({ game, hint, player }) => {
+  const headline = game.draw
+    ? "Draw"
+    : game.winner !== null
+      ? `${player.name} wins`
+      : `${player.name} to move`;
+
+  return (
+    <Container
+      className={game.draw ? "draw" : undefined}
+      role="status"
+      style={{ "--slot": player.color }}
+    >
+      <Chip aria-hidden="true">{game.draw ? "—" : player.initial}</Chip>
+      <Copy>
+        <Headline style={game.draw ? { color: "var(--foreground)" } : undefined}>
+          {headline}
+        </Headline>
+        <Hint>
+          {hint ??
+            (game.draw
+              ? "Forty-two pieces, no line."
+              : game.winner !== null
+                ? `${game.winningLine.length} in a row.`
+                : "Four in a row. Nothing found.")}
+        </Hint>
+      </Copy>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/components/VisuallyHidden.js
+++ b/src/app/(pages)/games/connect-404/components/VisuallyHidden.js
@@ -1,0 +1,17 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+// Text for screen readers only. Clipped rather than `display: none`, which
+// would take it out of the accessibility tree along with everything else.
+export const VisuallyHidden = styled.span`
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`;

--- a/src/app/(pages)/games/connect-404/components/index.js
+++ b/src/app/(pages)/games/connect-404/components/index.js
@@ -1,0 +1,4 @@
+export * from "./Announcer";
+export * from "./Endgame";
+export * from "./TurnBanner";
+export * from "./VisuallyHidden";

--- a/src/app/(pages)/games/connect-404/context/actions.js
+++ b/src/app/(pages)/games/connect-404/context/actions.js
@@ -1,0 +1,31 @@
+/**
+ * The two things that can happen to a Connect 404 game.
+ *
+ * Action creators rather than bare objects because an online room (#114) has to
+ * translate the same intents onto the wire, and it should be translating one
+ * named shape rather than guessing at object literals scattered through the
+ * components.
+ */
+
+export const DROP_PIECE = "DROP PIECE";
+export const NEW_GAME = "NEW GAME";
+
+/**
+ * Drop a piece into a column.
+ *
+ * @param {Number} col - 0-based column
+ * @param {String|Number} slot - Who is dropping it. Passed explicitly rather
+ *   than read off `state.turn` because online the server decides whose move
+ *   this is, and the reducer must be able to refuse a slot that is not up.
+ */
+export const dropPiece = (col, slot) => ({ type: DROP_PIECE, col, slot });
+
+/**
+ * Start over.
+ *
+ * @param {Object} [options]
+ * @param {String|Number} [options.first] - Who opens. Omit and the reducer
+ *   works it out: the winner of the game just finished, or — after a draw — the
+ *   player who did not open it.
+ */
+export const newGame = (options = {}) => ({ type: NEW_GAME, ...options });

--- a/src/app/(pages)/games/connect-404/context/index.jsx
+++ b/src/app/(pages)/games/connect-404/context/index.jsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useMemo, useReducer } from "react";
+
+import reducer from "./reducer";
+// Aliased: `newGame` is also the name of the action creator this module
+// re-exports, and they are different things — one builds a state, one asks for
+// one.
+import { newGame as freshGame } from "./reducer/newGame";
+
+export const createDefaultState = () => freshGame();
+
+export const Context = createContext({
+  state: createDefaultState(),
+  dispatch: () => {},
+  // Null means "this device is the whole game". An online room (#114) fills it
+  // with the per-player view — which seat is yours, the code, the connection —
+  // and that is the only thing below this provider that knows the difference.
+  online: null,
+});
+
+/**
+ * The local hotseat game — two players passing one device.
+ *
+ * Online play swaps this provider for one backed by a room and fills the
+ * identical value shape — `{ state: { game, players, first }, dispatch, online }`
+ * — so everything below keeps working, because nothing below knows where the
+ * state came from. `online` is the only difference, and `Game` reads exactly two
+ * facts off it: which slot this device plays, and whether it may move.
+ */
+export const ContextProvider = ({ children }) => {
+  // Lazily built, but from constants only — the page is prerendered, so the
+  // first client render has to produce exactly the markup the server did.
+  const [state, dispatch] = useReducer(reducer, undefined, createDefaultState);
+
+  const store = useMemo(
+    () => ({ state, dispatch, online: null }),
+    [state, dispatch]
+  );
+
+  return <Context.Provider value={store}>{children}</Context.Provider>;
+};
+
+export * from "./actions";

--- a/src/app/(pages)/games/connect-404/context/reducer/index.js
+++ b/src/app/(pages)/games/connect-404/context/reducer/index.js
@@ -1,0 +1,42 @@
+import { createState, dropPiece as drop, resetState } from "../../_lib";
+import { DROP_PIECE, NEW_GAME } from "../actions";
+import { newGame } from "./newGame";
+
+export { newGame };
+
+/**
+ * The hotseat store.
+ *
+ * Thin on purpose: every rule lives in `_lib`, and this only decides which of
+ * them to ask. An online room (#114) runs the same `_lib` on the server through
+ * `_lib/reducer`, so a rule restated here would be a rule that could disagree
+ * with itself.
+ */
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case DROP_PIECE: {
+      // The engine refuses a full column, a slot that is not up and a finished
+      // game, and hands back the state it was given — the same reference — when
+      // it does. That identity check is the whole rejection path: nothing here
+      // has to know which rules exist, only that one of them said no.
+      const { state: game } = drop(state.game, action.col, action.slot);
+      return game === state.game ? state : { ...state, game };
+    }
+
+    case NEW_GAME:
+      return {
+        ...state,
+        // `resetState` is where "the winner opens the next game" lives — and
+        // where a draw falls back to join order. It is the engine's rule and
+        // the server will apply the same one, so it is not restated here.
+        game: action.first
+          ? createState({ slots: state.game.slots, first: action.first })
+          : resetState(state.game),
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/app/(pages)/games/connect-404/context/reducer/newGame.js
+++ b/src/app/(pages)/games/connect-404/context/reducer/newGame.js
@@ -1,0 +1,14 @@
+import { createState } from "../../_lib";
+import { createPlayers, HOTSEAT_SLOTS } from "../../players";
+
+/**
+ * A fresh state, cast and all.
+ *
+ * @param {Object} [options]
+ * @param {String|Number} [options.first] - Who opens; defaults to the first slot
+ * @returns {Object} `{ game, players }`
+ */
+export const newGame = ({ first } = {}) => ({
+  game: createState({ slots: HOTSEAT_SLOTS, first }),
+  players: createPlayers(HOTSEAT_SLOTS),
+});

--- a/src/app/(pages)/games/connect-404/hooks/index.js
+++ b/src/app/(pages)/games/connect-404/hooks/index.js
@@ -1,0 +1,1 @@
+export * from "./useColumnNavigation";

--- a/src/app/(pages)/games/connect-404/hooks/useColumnNavigation.js
+++ b/src/app/(pages)/games/connect-404/hooks/useColumnNavigation.js
@@ -1,0 +1,73 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { clamp } from "lodash";
+
+/**
+ * Keyboard access to the board.
+ *
+ * Seven columns share one tab stop — a roving tabindex — rather than taking
+ * seven of them, so a player tabbing through the page passes the board in one
+ * press and steers inside it with the arrows. Left and right choose a column;
+ * enter and space drop, which they do by themselves because every column is a
+ * real button.
+ *
+ * Down drops too. It is the direction the piece goes, a keyboard player's hand
+ * is already on the arrows, and the column's own label says so.
+ *
+ * Every column is reachable, full or not: surveying the board is not the same
+ * as moving on it, and a keyboard player has to be able to do the first.
+ *
+ * @param {Number} cols - How many columns there are
+ * @param {Function} onActivate - `(col) => void`, for the down arrow
+ * @returns {Object} The column that owns the tab stop, a ref registrar, and the
+ *   keydown handler to hang off every column
+ */
+export const useColumnNavigation = (cols, onActivate) => {
+  const [activeColumn, setActiveColumn] = useState(0);
+  const elements = useRef(new Map());
+
+  const register = useCallback(
+    (col) => (element) => {
+      if (element) elements.current.set(col, element);
+      else elements.current.delete(col);
+    },
+    []
+  );
+
+  const focusColumn = useCallback((col) => {
+    setActiveColumn(col);
+    elements.current.get(col)?.focus();
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event, col) => {
+      // Clamped rather than wrapped. Seven columns is few enough that a player
+      // holding an arrow down is aiming at the end of the row, and wrapping
+      // would carry them past it to the other side of the board.
+      const target = {
+        ArrowLeft: () => clamp(col - 1, 0, cols - 1),
+        ArrowRight: () => clamp(col + 1, 0, cols - 1),
+        Home: () => 0,
+        End: () => cols - 1,
+      }[event.key];
+
+      if (target) {
+        // Swallowed even at the rim, so the page never scrolls out from under
+        // a player steering the board.
+        event.preventDefault();
+        focusColumn(target());
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        onActivate(col);
+      }
+    },
+    [cols, focusColumn, onActivate]
+  );
+
+  return useMemo(
+    () => ({ activeColumn, focusColumn, onKeyDown, register }),
+    [activeColumn, focusColumn, onKeyDown, register]
+  );
+};

--- a/src/app/(pages)/games/connect-404/page.js
+++ b/src/app/(pages)/games/connect-404/page.js
@@ -1,0 +1,25 @@
+import { Connect404 } from "./Connect404";
+
+// "Connect 404" is the name; "connect four" is what people search for. Both
+// stay in the description and keywords so the page is findable either way.
+export const metadata = {
+  title: "Connect 404 — Connect Four | Christopher Salinas Jr.",
+  description:
+    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device, seven columns, six rows, and a piece that falls where gravity puts it.",
+  keywords: [
+    "connect four",
+    "connect 4",
+    "connect four online",
+    "connect four 2 player",
+    "four in a row",
+    "Connect 404",
+  ],
+  openGraph: {
+    title: "Connect 404 — Connect Four",
+    description:
+      "Four in a row. Nothing found. Two players, one device, seven columns and gravity.",
+    type: "website",
+  },
+};
+
+export default Connect404;

--- a/src/app/(pages)/games/connect-404/players.js
+++ b/src/app/(pages)/games/connect-404/players.js
@@ -1,0 +1,95 @@
+/**
+ * Connect 404 — who is who, and what colour they are.
+ *
+ * The engine only ever deals in opaque "slots". Everything a human needs to
+ * tell one slot from another — a name, an initial, a colour — lives here, in
+ * ONE shape that both the hotseat game and an online room (#114) build:
+ *
+ *   { slot, name, initial, color, colorName, token }
+ *
+ * `color` is a CSS custom property reference, so it resolves anywhere the theme
+ * does and stays in step with it.
+ *
+ * Colour is never the only signal. Every piece is stamped with its player's
+ * initial as well as filled with their colour — red and blue is a kinder pair
+ * than most, but "the red one" is still not a description a monochrome screen
+ * or a protanope can act on.
+ */
+
+// Red first, blue second, straight out of the reference implementation
+// (`csalinas-dev/connect4`, where P1 is a red disc and P2 a blue one) and off
+// the site palette rather than out of a crayon box.
+export const PLAYER_PALETTE = Object.freeze([
+  { choice: "red", colorName: "Red", color: "var(--invalid)", token: "--invalid" },
+  {
+    choice: "blue",
+    colorName: "Blue",
+    color: "var(--component)",
+    token: "--component",
+  },
+]);
+
+/** The colours a room offers, in the order the picker shows them. */
+export const COLOR_CHOICES = Object.freeze(PLAYER_PALETTE.map((p) => p.choice));
+
+/**
+ * Wire colour name → palette entry.
+ * @param {String} choice - "red" | "blue"
+ * @returns {?Object} The palette entry, or null for anything unrecognised
+ */
+export const paletteFor = (choice) =>
+  PLAYER_PALETTE.find((entry) => entry.choice === choice) ?? null;
+
+// The slot ids a local hotseat game uses. Strings rather than numbers, matching
+// Edge Case: a slot ends up as an object key often enough that it may as well
+// already be one.
+export const HOTSEAT_SLOTS = Object.freeze(["p1", "p2"]);
+
+/**
+ * Player descriptors for a list of slots, in join order.
+ *
+ * Names default to the colour ("Red", "Blue") because on a shared device the
+ * colour IS the identity — nobody has typed a name in. An online room hands in
+ * real names instead; the initial follows whatever name it is given.
+ *
+ * @param {(String|Number)[]} slots - Slots in join order, at most two
+ * @param {Object} [options]
+ * @param {String[]} [options.names] - Display names, positional, optional
+ * @param {String[]} [options.colors] - Chosen colours ("red", "blue"), positional
+ * @returns {Object[]} One `{ slot, name, initial, color, colorName, token }` per slot
+ */
+export const createPlayers = (slots, { names = [], colors = [] } = {}) =>
+  slots.slice(0, PLAYER_PALETTE.length).map((slot, index) => {
+    const { color, colorName, token } =
+      paletteFor(colors[index]) ?? PLAYER_PALETTE[index];
+    const name = names[index] || colorName;
+
+    return {
+      slot,
+      name,
+      // Trimmed first, so " chris" still initials as "C" rather than a space.
+      initial: name.trim().charAt(0).toUpperCase() || colorName.charAt(0),
+      color,
+      colorName,
+      token,
+    };
+  });
+
+/**
+ * Slot → player descriptor, for the many components that hold a slot and need a
+ * colour. Falls back to a neutral descriptor rather than throwing, so a
+ * mismatched slot can never blank the board mid-game.
+ *
+ * @param {Object[]} players - Player descriptors
+ * @param {String|Number} slot - The slot to look up
+ * @returns {Object} A player descriptor
+ */
+export const playerFor = (players, slot) =>
+  players.find((player) => player.slot === slot) ?? {
+    slot,
+    name: "Player",
+    initial: "?",
+    color: "var(--foreground)",
+    colorName: "grey",
+    token: "--foreground",
+  };


### PR DESCRIPTION
Part of #111. Consumes the engine from #112, which is already merged into this base branch.

`/games/connect-404` is playable hotseat: seven columns, six rows, red is slot 0 and blue is slot 1.

## The animation

The issue asks for it specifically, so it is worth being precise about what it does *not* do: **it does not decide anything.** A piece is rendered in the cell `dropPiece` put it in before a single frame runs, and every keyframe of the fall is an *offset* from that cell ending at zero. There is no frame in which a piece is anywhere but its own cell — only frames in which it is drawn above it. Turn the animation off entirely, as `prefers-reduced-motion` does, and the board is in exactly the same place.

The geometry that makes that work: cells are square and stacked with **no gap** (the space between the sockets comes from the sockets being smaller than the cells), so one cell is exactly 100% of the animating element's height and the fall distance is `rows - landingRow` counted in cells. Longer falls take longer — `calc(150ms + var(--drop) * 52ms)` — because the same variable is unitless and can be multiplied by a time here and a length in the keyframes.

- **Hover preview** — a chute above the board holds the piece to be played. It slides across on `transform` following the cursor, and the arrow keys move it the same way. Over a full column it dims.
- **Win** — every cell of `winningLine` gets a permanent ring, plus a one-off swell staggered along the line so it reads as a line being drawn. Everything else dims. **Not sliced to four:** filling the gap in `● ● _ ● ●` is a genuine run of five and all five light up (verified in the browser).
- **Refusal** — a full column shakes, announces "Column N is full" on an assertive live region, and the drop never reaches the engine. The engine refuses it too and is still the authority; online this would be a round trip whose only possible answer is the one already on screen.
- **Reduced motion** — the fall, the swell, the shake, the chute slide and the endgame panel's entrance are all switched off. Pieces appear in place.

## The seam for #114

The board owns no game state. `Game.jsx` computes the two facts and passes them down, exactly as Edge Case does, so one board serves hotseat, online and spectator unchanged:

```jsx
<Board
  game={game}               // an engine state from _lib — the whole thing
  players={players}         // [{ slot, name, initial, color, colorName, token }] in join order
  youSlot={youSlot}         // the slot this device plays; null for a spectator
  interactive={interactive} // may this device drop a piece right now
  onDrop={onDrop}           // (col) => void — 0-based column, nothing else
  overlay={null}            // optional ReactNode over the panel, sized to it
/>
```

`Game` derives them the same way Edge Case's does:

```js
const youSlot = online ? online.youSlot : game.turn;
const interactive = online
  ? youSlot !== null && youSlot === game.turn && !game.finished
  : !game.finished;
```

The context value is `{ state: { game, players }, dispatch, online }`. `Game` also takes a `banner` prop, rendered above the board — the room strip goes there. `Connect404.jsx` is a two-line component that mounts `ContextProvider` + `Game`; the mode picker replaces its body and nothing underneath changes.

`Endgame` takes `{ game, winner, onPlayAgain }` and omitting `onPlayAgain` renders the result with no button, which is the spectator case.

## Judgement calls worth overruling

- **The endgame panel is under the board, not over it.** Edge Case puts its result in an `overlay` covering the board, and the `overlay` prop is still there for #114's "waiting for the other player" curtain — but the four highlighted pieces are what winning *looks like*, and covering them to announce the win would be announcing something the player can no longer see. It also holds its entrance back 620ms so it does not slide in on top of the line lighting up.
- **Pieces carry their player's initial.** The reference repo is plain discs, but the site's rule is that colour never carries a fact alone. It is an SVG `<text>` so it scales with the board rather than the root font size.
- **"Play again" defers entirely to `resetState`.** The winner opens the next game and a draw goes back to join order — the engine's rule, which the server will apply too, so it is not restated in the hotseat reducer.
- **Arrow-down drops.** It is the direction the piece goes and a keyboard player's hand is already on the arrows. Left/right/Home/End choose a column, enter and space drop natively because every column is a real `<button>`.
- **`getResult` is used only for the piece counts.** The end-of-game facts are read off the state (`winner`, `draw`, `finished`, `winningLine`) since the engine stores them there.

## Verified in the browser

Played to a win three ways (horizontal, vertical, diagonal), plus a five-in-a-row and a full 42-move draw:

- hover preview follows the cursor across columns and the arrow keys move it the same way
- drops land on the row `landingRow` names — a paused mid-fall frame shows the piece six cell-pitches above a DOM cell that is already the landing row
- four-in-a-row detected and highlighted; a run of five highlights all five
- a full column refuses visibly, announces itself, and adds no piece
- draw announced as a draw, on the board and in the live region
- winner opens the next game (Blue won, Blue opened)
- keyboard end to end: arrows, Home/End, enter, space and down
- reduced motion — the five `@media (prefers-reduced-motion: reduce)` rules are emitted against the right selectors, and with those declarations applied a drop produces zero animations, `transform: none`, and a piece whose top is identical to its cell's
- no horizontal overflow at 390, 360, 340 or 320px; columns are 44.5px wide and six cells tall at 360

Not touched, per #114: the online mode, the mode picker, `Nav.jsx`, `games/page.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
