### PR TITLE
feat(C404): online multiplayer and site integration

### DIFF
--- a/src/app/(pages)/games/connect-404/Connect404.jsx
+++ b/src/app/(pages)/games/connect-404/Connect404.jsx
@@ -1,20 +1,69 @@
 "use client";
 
-import { ContextProvider } from "./context";
-import Game from "./Game";
+import { useCallback, useEffect, useState } from "react";
 
-/**
- * Connect 404 — the page.
- *
- * One screen for now: the hotseat game, two players and one device. Online play
- * and the mode picker in front of it are #114's, and they replace the body of
- * this component rather than anything under it — `Game` and the board already
- * take their state from a context that does not care who fills it.
- */
-export const Connect404 = () => (
-  <ContextProvider>
-    <Game />
-  </ContextProvider>
-);
+import { isValidCode, normalizeCode } from "@/lib/realtime/codes";
+
+import Game from "./Game";
+import { Lobby } from "./Lobby";
+import { ContextProvider } from "./context";
+import { OnlineGame } from "./online";
+
+// Three screens, one page.
+//
+//   null     the mode picker
+//   "local"  the hotseat game — its own useReducer, no room, no hook, no
+//            request. The realtime core is not in this branch at all, which is
+//            what lets two people on a sofa play with the network switched off.
+//   "online" the same board driven by a room.
+//
+// Which one is showing is client state rather than a route: the board is not
+// something you want to navigate back into by accident, and the local game has
+// never had a URL of its own.
+
+export const Connect404 = () => {
+  const [mode, setMode] = useState(null);
+  const [code, setCode] = useState(null);
+
+  // A shared link (?room=K7F2) drops straight into that room. Read after mount
+  // rather than during render: this page is prerendered, so the first client
+  // render has to match the server's markup.
+  useEffect(() => {
+    const shared = normalizeCode(
+      new URLSearchParams(window.location.search).get("room") ?? "",
+    );
+    if (isValidCode(shared)) {
+      setCode(shared);
+      setMode("online");
+    }
+  }, []);
+
+  const play = useCallback((joined) => {
+    setCode(joined);
+    setMode("online");
+  }, []);
+
+  const leave = useCallback(() => {
+    setMode(null);
+    setCode(null);
+    // Drop ?room= as well, or "back to the menu" would bounce straight back in
+    // on the next reload.
+    window.history.replaceState(null, "", window.location.pathname);
+  }, []);
+
+  if (mode === "local") {
+    return (
+      <ContextProvider>
+        <Game />
+      </ContextProvider>
+    );
+  }
+
+  if (mode === "online" && code) {
+    return <OnlineGame code={code} onLeave={leave} />;
+  }
+
+  return <Lobby onOnline={play} onSameDevice={() => setMode("local")} />;
+};
 
 export default Connect404;

--- a/src/app/(pages)/games/connect-404/Lobby.jsx
+++ b/src/app/(pages)/games/connect-404/Lobby.jsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import styled from "@emotion/styled";
+
+import { isValidCode, normalizeCode } from "@/lib/realtime/codes";
+import { CODE_LENGTH } from "@/lib/realtime/constants";
+import { createRoom } from "@/lib/realtime/useRoom";
+
+import {
+  Button,
+  Panel,
+  PanelActions,
+  PanelError,
+  PanelHeading,
+  PanelText,
+} from "./components";
+import { C404_GAME_ID } from "./multiplayer";
+
+// The front door. Two ways to play and nothing else on screen, because the only
+// decision here is whether the other player is sitting next to you.
+//
+// Nothing on this screen touches the network until somebody chooses Online —
+// "Same device" is a state change and not a request, which is what keeps the
+// hotseat game playable with no server at all.
+
+const Choices = styled.div`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+  width: min(100%, 26rem);
+
+  @media (min-width: 600px) {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+
+const Choice = styled(Button)`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.35rem;
+  padding: 1.25rem 1rem;
+  text-align: center;
+`;
+
+const ChoiceTitle = styled.span`
+  font-size: 1.1rem;
+`;
+
+const ChoiceHint = styled.span`
+  color: var(--absentForeground);
+  font-size: 0.85rem;
+  line-height: 1.15rem;
+`;
+
+const Form = styled.form`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 1rem;
+`;
+
+const CodeInput = styled.input`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--absentForeground);
+  border-radius: 0.5rem;
+  color: var(--parenthesis);
+  font-family: inherit;
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  padding: 0.5rem 0 0.5rem 0.3em;
+  text-align: center;
+  text-transform: uppercase;
+  width: min(100%, 15rem);
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+export const Lobby = ({ onOnline, onSameDevice }) => {
+  // "pick" is the two-way choice; "join" is the code form. Creating a room has
+  // no screen of its own — it is one request and then you are in the room.
+  const [view, setView] = useState("pick");
+  const [entry, setEntry] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const create = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+
+    const result = await createRoom({ game: C404_GAME_ID });
+    if (result.ok) {
+      onOnline(result.code);
+      return;
+    }
+
+    setBusy(false);
+    setError(result.message ?? "Could not start a game. Try again in a moment.");
+  }, [onOnline]);
+
+  const join = useCallback(
+    (event) => {
+      event.preventDefault();
+      const code = normalizeCode(entry);
+      if (!isValidCode(code)) {
+        setError(`A game code is ${CODE_LENGTH} letters and numbers.`);
+        return;
+      }
+      // Whether the room is actually there is the room screen's question; it
+      // already has to answer it for a game that expires mid-session.
+      onOnline(code);
+    },
+    [entry, onOnline],
+  );
+
+  if (view === "join") {
+    return (
+      <Panel>
+        <PanelHeading>Join a game</PanelHeading>
+        <PanelText>Type the code the other player is looking at.</PanelText>
+        <Form onSubmit={join}>
+          <CodeInput
+            aria-label="Game code"
+            autoCapitalize="characters"
+            autoComplete="off"
+            autoCorrect="off"
+            autoFocus
+            maxLength={CODE_LENGTH}
+            onChange={(event) => {
+              setEntry(normalizeCode(event.target.value));
+              setError(null);
+            }}
+            spellCheck="false"
+            value={entry}
+          />
+          {error && <PanelError>{error}</PanelError>}
+          <PanelActions>
+            <Button
+              onClick={() => {
+                setView("pick");
+                setError(null);
+              }}
+              type="button"
+            >
+              Back
+            </Button>
+            <Button disabled={entry.length < CODE_LENGTH} type="submit">
+              Join game
+            </Button>
+          </PanelActions>
+        </Form>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <PanelHeading>Connect 404</PanelHeading>
+      <PanelText>
+        Drop a piece down one of seven columns. Four in a row — across, up or
+        diagonally — wins.
+      </PanelText>
+
+      <Choices>
+        <Choice onClick={onSameDevice} type="button">
+          <ChoiceTitle>
+            <span>
+              <i className="fa-solid fa-mobile-screen" />
+            </span>{" "}
+            Same device
+          </ChoiceTitle>
+          <ChoiceHint>Pass it back and forth. No connection needed.</ChoiceHint>
+        </Choice>
+        <Choice disabled={busy} onClick={create} type="button">
+          <ChoiceTitle>
+            <span>
+              <i className="fa-solid fa-globe" />
+            </span>{" "}
+            {busy ? "Starting…" : "Play online"}
+          </ChoiceTitle>
+          <ChoiceHint>
+            Get a code to share with somebody anywhere else.
+          </ChoiceHint>
+        </Choice>
+      </Choices>
+
+      {error && <PanelError>{error}</PanelError>}
+
+      <PanelActions>
+        <Button onClick={() => setView("join")} type="button">
+          I have a code
+        </Button>
+      </PanelActions>
+    </Panel>
+  );
+};
+
+export default Lobby;

--- a/src/app/(pages)/games/connect-404/components/Button.jsx
+++ b/src/app/(pages)/games/connect-404/components/Button.jsx
@@ -1,0 +1,29 @@
+import styled from "@emotion/styled";
+
+// The game's one button. The mode picker, the join form, the waiting room and
+// the endgame panel all press the same thing.
+export const Button = styled.button`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--selectionBackground);
+  border-radius: 0.5rem;
+  color: var(--foreground);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1rem;
+  padding: 0.5rem 1.25rem;
+  transition: background-color ease-in-out 150ms;
+
+  &:hover {
+    background-color: var(--absentBackground);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    color: var(--absentForeground);
+    cursor: default;
+  }
+`;

--- a/src/app/(pages)/games/connect-404/components/Panel.jsx
+++ b/src/app/(pages)/games/connect-404/components/Panel.jsx
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+
+// Every screen that is not the board — the mode picker, the join form, the
+// waiting room, a lost connection. They share one shell so moving between them
+// never shifts the layout, and so all of them sit in the same place the board
+// would (same flex growth, same top padding to clear the toolbar).
+
+export const Panel = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-flow: column nowrap;
+  gap: 1.25rem;
+  justify-content: center;
+  padding: 3.5rem 1.5rem 1.5rem;
+  text-align: center;
+  width: 100%;
+`;
+
+export const PanelHeading = styled.h1`
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+  margin: 0;
+
+  @media (min-width: 600px) {
+    font-size: 1.75rem;
+  }
+`;
+
+export const PanelText = styled.p`
+  color: var(--absentForeground);
+  line-height: 1.5rem;
+  margin: 0;
+  max-width: 30rem;
+`;
+
+/** Reserved for something the player did wrong — a bad code, a dead room. */
+export const PanelError = styled(PanelText)`
+  color: var(--invalid);
+`;
+
+export const PanelActions = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.75rem;
+  justify-content: center;
+`;

--- a/src/app/(pages)/games/connect-404/components/index.js
+++ b/src/app/(pages)/games/connect-404/components/index.js
@@ -1,4 +1,6 @@
 export * from "./Announcer";
+export * from "./Button";
 export * from "./Endgame";
+export * from "./Panel";
 export * from "./TurnBanner";
 export * from "./VisuallyHidden";

--- a/src/app/(pages)/games/connect-404/multiplayer.js
+++ b/src/app/(pages)/games/connect-404/multiplayer.js
@@ -1,0 +1,100 @@
+import { defineGame } from "@/lib/realtime/games";
+
+import { createState, reducer as engineReducer, resetState } from "./_lib";
+import { NEW_GAME } from "./context/actions";
+
+// The networked half of Connect 404: the rules the engine already plays,
+// wrapped in the shape src/lib/realtime asks for.
+//
+// Named `multiplayer.js` rather than the `game.js` the core's README suggests
+// because `Game.jsx` sits beside it, and two modules whose names differ only in
+// case resolve to each other on Windows and macOS — webpack calls that a real
+// casing collision and refuses to build.
+//
+// This module is pure on purpose. It is imported by the API routes (where it is
+// the authority) *and* by the browser (where `useRoom` runs it to preview a
+// drop), so it must contain no JSX, no `window`, no clock and no randomness —
+// the two copies have to agree exactly or the optimistic board drifts. The two
+// modules it imports are pure for the same reason.
+//
+// Every rule below is *called*, never restated: `_lib`'s reducer is the same
+// function the hotseat store dispatches to, and its `resetState` is the same
+// "new game". A second implementation of "four in a row" would drift silently,
+// and it is the rule players would notice last.
+
+export const C404_GAME_ID = "connect-404";
+
+// Both seats exist from the moment the room does, so the board can too. An
+// ARRAY, in seat order, because it becomes the engine's turn order and MySQL
+// does not preserve the key order of anything else stored in a room.
+export const SEATS = Object.freeze([0, 1]);
+
+/** The seat that opens the very first game of a room. */
+export const FIRST_SEAT = SEATS[0];
+
+// The engine reports a refusal as `{ code, message }` so a caller can branch on
+// the code; the core wants the one sentence it will put in a 422 and a player
+// will read. Flattening that is the whole reason this adapter exists — hand the
+// object through and the browser renders "[object Object]".
+const refusal = (error) =>
+  (typeof error === "string" ? error : error?.message) ||
+  "That move is not allowed.";
+
+export const connect404 = defineGame({
+  id: C404_GAME_ID,
+  maxPlayers: 2,
+  minPlayers: 2,
+  // Nothing to pick, so nothing to negotiate: red is whoever created the room
+  // and blue is whoever joined it, which makes a colour a seat. An empty palette
+  // leaves `player.color` null rather than storing a second answer that could
+  // disagree with `players.js` — that module is the only one that says what a
+  // seat looks like.
+  colors: [],
+  // Two seats, and gravity on a seven-wide board only divides two ways.
+  allowLateJoin: false,
+
+  // Deliberately ignores the roster it is handed: `_lib/createState` THROWS on
+  // anything but exactly two slots, and a room is created with one player in
+  // it. The seats are fixed and known, so the board is built from those and the
+  // second one is filled the moment somebody joins.
+  createState: () => createState({ slots: [...SEATS], first: FIRST_SEAT }),
+
+  /**
+   * The server's authority and the client's preview, in one function.
+   *
+   * `player` is resolved from the request's token by the core, so "it is not
+   * your turn" is checked against a seat the client had no say in choosing —
+   * request bodies never name a slot. Everything but the rematch is handed
+   * straight to the engine.
+   */
+  reducer: (state, action, player) => {
+    // The one action the engine has no opinion about: a new game is a room-level
+    // event, not a move. Either player may ask for it, so the next game never
+    // waits on the one who just lost to press something — and `resetState` is
+    // where "the winner opens the next game" lives, falling back to seat order
+    // after a draw. Same function the hotseat store calls.
+    if (action?.type === NEW_GAME) {
+      if (!state.slots.includes(player.slot)) {
+        return { error: "You are not seated at this board." };
+      }
+      if (!state.finished) {
+        return { error: "Finish this game before starting the next one." };
+      }
+      return { state: resetState(state) };
+    }
+
+    const result = engineReducer(state, action, player);
+    if (result.error) return { error: refusal(result.error) };
+    return { state: result.state };
+  },
+
+  // Derived, never stored. "lobby" is what puts the waiting screen up until the
+  // second player arrives; "over" is what stops a stranger with the code
+  // wandering into a finished room and taking a seat.
+  status: (state, players) => {
+    if (players.length < SEATS.length) return "lobby";
+    return state.finished ? "over" : "playing";
+  },
+});
+
+export default connect404;

--- a/src/app/(pages)/games/connect-404/online/OnlineBar.jsx
+++ b/src/app/(pages)/games/connect-404/online/OnlineBar.jsx
@@ -1,0 +1,157 @@
+import { useContext } from "react";
+import styled from "@emotion/styled";
+
+import { AWAY, LEFT, absenceSentence } from "@/lib/realtime/absence";
+
+import { Button } from "../components";
+import { Context } from "../context";
+import { playerFor } from "../players";
+
+// The per-player strip above the board: which room this is, which colour is
+// yours, who you are playing, and anything the connection wants to admit to.
+// Everything it needs is already on the context, so it is rendered as <Game>'s
+// banner from inside the provider and takes no props but the way out.
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+  line-height: 1.25rem;
+  text-align: center;
+`;
+
+const Row = styled.div`
+  align-items: center;
+  column-gap: 1rem;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  row-gap: 0.25rem;
+`;
+
+const Item = styled.span`
+  align-items: center;
+  color: var(--absentForeground);
+  display: inline-flex;
+  gap: 0.4rem;
+`;
+
+const Code = styled.span`
+  color: var(--parenthesis);
+  font-weight: 700;
+  letter-spacing: 0.15em;
+`;
+
+// The disc the board will drop for you, at the size of a word — and the colour
+// is named beside it, because "the red one" is not a description a monochrome
+// screen or a protanope can act on.
+const Chip = styled.span`
+  background-color: ${({ color }) => color};
+  border-radius: 50%;
+  display: inline-block;
+  height: 0.9rem;
+  width: 0.9rem;
+`;
+
+const Leave = styled.button`
+  background: none;
+  border: none;
+  color: var(--vscode);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  padding: 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+// Reconnecting is ordinary and a refused move is not, but both are the same
+// kind of interruption to a player: something is wrong and it is not the board.
+const Warning = styled.div`
+  color: var(--invalid);
+`;
+
+// The opponent, not the connection — so deliberately not a Warning. Nothing is
+// broken here; somebody is either briefly away or has gone home, and the two
+// are told apart by tone as much as by wording.
+const Absence = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.5rem;
+
+  /* A blink. Said once, quietly, in the same voice as the rest of the strip. */
+  &.away {
+    color: var(--absentForeground);
+  }
+
+  /* Final. Worth a colour, because the board below it will never move again. */
+  &.left {
+    color: var(--string);
+  }
+`;
+
+const Ending = styled(Button)`
+  font-size: 0.9rem;
+  padding: 0.35rem 0.9rem;
+`;
+
+export const OnlineBar = ({ onLeave }) => {
+  const { online, state } = useContext(Context);
+  const { absence, code, connected, notice, opponent, spectating, youSlot } =
+    online;
+
+  // The same descriptor the board draws your discs from, so the strip and the
+  // board cannot end up disagreeing about what colour you are.
+  const you = spectating ? null : playerFor(state.players, youSlot);
+
+  return (
+    <Container>
+      <Row>
+        <Item>
+          Room <Code>{code}</Code>
+        </Item>
+        {you ? (
+          <>
+            <Item>
+              You are <Chip aria-hidden="true" color={you.color} />
+              {you.colorName}
+            </Item>
+            <Item>vs {opponent}</Item>
+          </>
+        ) : (
+          <Item>Watching — this room is full</Item>
+        )}
+        <Item>
+          <Leave onClick={onLeave} type="button">
+            Leave
+          </Leave>
+        </Item>
+      </Row>
+      {absence !== null && (
+        // `role="status"` for both: neither is an emergency, and an assertive
+        // alert would cut across whatever a screen reader was in the middle of
+        // saying about the board.
+        <Absence className={absence} role="status">
+          <span>{absenceSentence(opponent, absence)}</span>
+          {absence === AWAY && (
+            <span>The board picks up where it left off.</span>
+          )}
+          {absence === LEFT && (
+            <Ending onClick={onLeave} type="button">
+              Back to the menu
+            </Ending>
+          )}
+        </Absence>
+      )}
+      {!connected && <Warning role="status">Reconnecting…</Warning>}
+      {notice !== null && <Warning role="alert">{notice}</Warning>}
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/online/OnlineGame.jsx
+++ b/src/app/(pages)/games/connect-404/online/OnlineGame.jsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+import { absenceOf } from "@/lib/realtime/absence";
+import { useRoom } from "@/lib/realtime/useRoom";
+
+import Game from "../Game";
+import {
+  Button,
+  Panel,
+  PanelActions,
+  PanelHeading,
+  PanelText,
+} from "../components";
+import { DROP_PIECE, NEW_GAME } from "../context/actions";
+import { Context } from "../context";
+import { C404_GAME_ID, SEATS } from "../multiplayer";
+import { createPlayers } from "../players";
+import { OnlineBar } from "./OnlineBar";
+import { RoomCode } from "./RoomCode";
+
+/**
+ * Online Connect 404: the same board, driven by a realtime room.
+ *
+ * This component's whole job is to fill the game's context from `useRoom`
+ * instead of from a `useReducer`. The board, the turn banner and the endgame
+ * panel do not know the difference, which is the point — there is one board in
+ * this codebase, not two.
+ */
+export const OnlineGame = ({ code, onLeave }) => {
+  const {
+    connected,
+    error,
+    leave,
+    me,
+    players: seats,
+    room,
+    send,
+    spectating,
+    state: game,
+    status,
+  } = useRoom({ code, game: C404_GAME_ID });
+
+  const [notice, setNotice] = useState(null);
+
+  // The seat this browser holds, resolved by the server from its token. Null for
+  // a spectator, which is what closes the board to them.
+  const youSlot = me?.slot ?? null;
+  // Null for a spectator on purpose: they are not playing anybody, and picking
+  // one of the two seats arbitrarily would put "so-and-so left the game" on a
+  // screen that has no stake in it.
+  const opponent =
+    youSlot === null
+      ? null
+      : (seats.find((seat) => seat.slot !== youSlot) ?? null);
+
+  // Walking away is not the same as navigating away. Giving the seat up first
+  // is what turns "the board just stopped" into a sentence on the other
+  // player's screen; without it they wait out the presence timeout for news
+  // that was available the instant this button was pressed.
+  const quit = useCallback(async () => {
+    await leave();
+    onLeave();
+  }, [leave, onLeave]);
+
+  // A drop goes over the wire without the slot the hotseat action carries: the
+  // server resolves who moved from the request's token, and a slot in a body is
+  // a slot somebody can lie about. Everything else about the move — a full
+  // column, whose turn it is, whether four are in a row — is the engine's, and
+  // it is the same engine at both ends.
+  const drop = useCallback(
+    async (col) => {
+      const action = { type: DROP_PIECE, col };
+      let result = await send(action, { optimistic: true });
+
+      // 409 means the opponent's drop landed between the render we tapped and
+      // the request we sent. `send` has already applied the board we missed, so
+      // the same tap is worth exactly one more try against it — and only one,
+      // because a second failure means the column really is contested.
+      if (!result.ok && result.error === "stale-revision") {
+        result = await send(action, { optimistic: true });
+      }
+
+      setNotice(result.ok ? null : (result.message ?? null));
+    },
+    [send],
+  );
+
+  const rematch = useCallback(async () => {
+    const result = await send({ type: NEW_GAME });
+    // Both players may reach for it at once. Losing that race is not something
+    // to put on screen — the new board is already on its way.
+    const raced =
+      result.error === "stale-revision" || result.error === "rejected";
+    setNotice(result.ok || raced ? null : (result.message ?? null));
+  }, [send]);
+
+  // The hotseat store's action creators, answered over the wire. Same actions
+  // in, same board out; only the authority moved.
+  const dispatch = useCallback(
+    (action) => {
+      switch (action?.type) {
+        case DROP_PIECE:
+          drop(action.col);
+          break;
+        case NEW_GAME:
+          rematch();
+          break;
+        default:
+          break;
+      }
+    },
+    [drop, rematch],
+  );
+
+  // The board's cast, built by the same function the hotseat game uses so the
+  // colours, initials and fallbacks are identical in both modes. Names are
+  // positional against SEATS, never against the room's roster — a player who has
+  // left keeps their seat and their place in this list, and a room in the lobby
+  // has a hole in it.
+  const cast = useMemo(
+    () =>
+      createPlayers([...SEATS], {
+        names: SEATS.map(
+          (slot) => seats.find((seat) => seat.slot === slot)?.name,
+        ),
+      }),
+    [seats],
+  );
+
+  const store = useMemo(
+    () => ({
+      state: { game, players: cast },
+      dispatch,
+      online: {
+        // Left or dropped, so the bar can explain a board that has stopped
+        // moving. Mid-game the seat is never deleted — it has to stay for the
+        // turn order to make sense — so this is the only way the other player
+        // finds out.
+        absence: absenceOf(opponent),
+        code,
+        connected,
+        notice,
+        opponent: opponent?.name ?? "your opponent",
+        spectating,
+        // `Game` reads exactly this off `online`, and closes the board when it
+        // is not the seat on the clock.
+        youSlot,
+      },
+    }),
+    [
+      cast,
+      code,
+      connected,
+      dispatch,
+      game,
+      notice,
+      opponent,
+      spectating,
+      youSlot,
+    ],
+  );
+
+  // 410 is terminal and reads differently depending on whether we ever got in:
+  // a room we were playing in has died, a room we never reached never existed.
+  if (error?.code === "gone") {
+    return (
+      <Panel>
+        <PanelHeading>Connection lost</PanelHeading>
+        <PanelText>
+          {room
+            ? "This room is gone — a game closes after an hour without a move. Create a new game to play again."
+            : `Nothing is waiting on ${code}. Check the code, or create a new game to play again.`}
+        </PanelText>
+        <PanelActions>
+          <Button onClick={onLeave} type="button">
+            Back to the menu
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  // No snapshot yet. An `error` here is the handshake failing rather than the
+  // room being dead, so the hook is still retrying behind this screen.
+  if (!room) {
+    return (
+      <Panel>
+        <PanelHeading>
+          {error ? "Can’t reach the game" : "Connecting…"}
+        </PanelHeading>
+        {error && <PanelText>{error.message}</PanelText>}
+        <PanelActions>
+          <Button onClick={onLeave} type="button">
+            Back to the menu
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  if (status === "lobby") {
+    return (
+      <Panel>
+        <PanelHeading>Waiting for a second player</PanelHeading>
+        <PanelText>
+          Read this code out, or send the link. The game starts the moment
+          somebody joins.
+        </PanelText>
+        <RoomCode code={code} />
+        <PanelActions>
+          <Button onClick={quit} type="button">
+            Cancel
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  return (
+    <Context.Provider value={store}>
+      <Game banner={<OnlineBar onLeave={quit} />} />
+    </Context.Provider>
+  );
+};
+
+export default OnlineGame;

--- a/src/app/(pages)/games/connect-404/online/RoomCode.jsx
+++ b/src/app/(pages)/games/connect-404/online/RoomCode.jsx
@@ -1,0 +1,57 @@
+import { useCallback, useState } from "react";
+import styled from "@emotion/styled";
+
+import { Button } from "../components";
+
+// The code is the whole invitation, so it is the biggest thing on the screen
+// and it is spelled out for a screen reader one letter at a time — "K7F2" read
+// as a word helps nobody.
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 1rem;
+`;
+
+const Code = styled.div`
+  color: var(--parenthesis);
+  font-size: clamp(3.5rem, 20vw, 6rem);
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  line-height: 1.1;
+  /* letter-spacing pads the right of the final glyph too; pull the block back
+     by the same amount so the code still reads as centred. */
+  text-indent: 0.3em;
+`;
+
+export const RoomCode = ({ code }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    const { origin, pathname } = window.location;
+    try {
+      await navigator.clipboard.writeText(`${origin}${pathname}?room=${code}`);
+      setCopied(true);
+    } catch {
+      // Clipboard access can be refused outright (an insecure origin, a
+      // permission prompt dismissed). The code is on screen either way, which
+      // is the part that actually matters.
+      setCopied(false);
+    }
+  }, [code]);
+
+  return (
+    <Container>
+      <Code aria-label={`Room code ${[...code].join(" ")}`} role="img">
+        {code}
+      </Code>
+      <Button onClick={copy} type="button">
+        <span>
+          <i className="fa-regular fa-copy" />
+        </span>{" "}
+        {copied ? "Link copied!" : "Copy invite link"}
+      </Button>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/online/index.js
+++ b/src/app/(pages)/games/connect-404/online/index.js
@@ -1,0 +1,3 @@
+export * from "./OnlineBar";
+export * from "./OnlineGame";
+export * from "./RoomCode";

--- a/src/app/(pages)/games/connect-404/page.js
+++ b/src/app/(pages)/games/connect-404/page.js
@@ -5,7 +5,7 @@ import { Connect404 } from "./Connect404";
 export const metadata = {
   title: "Connect 404 — Connect Four | Christopher Salinas Jr.",
   description:
-    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device, seven columns, six rows, and a piece that falls where gravity puts it.",
+    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device or online with a code, seven columns, six rows, and a piece that falls where gravity puts it.",
   keywords: [
     "connect four",
     "connect 4",
@@ -17,7 +17,7 @@ export const metadata = {
   openGraph: {
     title: "Connect 404 — Connect Four",
     description:
-      "Four in a row. Nothing found. Two players, one device, seven columns and gravity.",
+      "Four in a row. Nothing found. Two players, one device or two, seven columns and gravity.",
     type: "website",
   },
 };

--- a/src/app/(pages)/games/page.jsx
+++ b/src/app/(pages)/games/page.jsx
@@ -18,7 +18,8 @@ const Container = styled.div`
   grid-template-areas:
     "wordle hashtag"
     "tictacoverflow tictacoverflow"
-    "edgecase edgecase";
+    "edgecase edgecase"
+    "connect404 connect404";
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto;
 
@@ -42,15 +43,26 @@ const Container = styled.div`
     grid-area: edgecase;
   }
 
+  .connect404 {
+    aspect-ratio: 2 / 1;
+    grid-area: connect404;
+  }
+
   @media (min-width: 896px) {
     gap: 3rem;
   }
 
+  /* One row, and from here on every card is the same tall portrait. The old
+     layout gave Edge Case a double-width column, which only looked square
+     because the row was as tall as the 1:2 cards beside it; a fifth game makes
+     five equal columns both simpler and narrower than that column ever was. */
   @media (min-width: 1296px) {
-    grid-template-areas: "wordle hashtag tictacoverflow edgecase";
-    grid-template-columns: 1fr 1fr 1fr 2fr;
+    grid-template-areas: "wordle hashtag tictacoverflow edgecase connect404";
+    grid-template-columns: repeat(5, 1fr);
 
-    .tictacoverflow {
+    .tictacoverflow,
+    .edgecase,
+    .connect404 {
       aspect-ratio: 1 / 2;
     }
   }
@@ -272,6 +284,88 @@ const EdgeCaseArtwork = () => {
   );
 };
 
+// Seven columns, six rows, and the columns are written bottom-up — the same way
+// round they are in the engine, where `columns[c][0]` is the disc resting on the
+// floor. Red has just taken the bottom row; a ghost hangs over column six to say
+// that a turn here is a column, not a square.
+const C404_CELL = 42;
+const C404_ORIGIN = { x: 3, y: 48 };
+const C404_COLUMNS = [
+  ["blue"],
+  ["red", "blue"],
+  ["red", "blue", "red"],
+  ["red", "blue"],
+  ["red"],
+  [],
+  [],
+];
+const C404_WIN = [1, 2, 3, 4];
+const C404_FILL = { red: "#f44747", blue: "#4fc1ff" };
+
+const c404x = (col) => C404_ORIGIN.x + C404_CELL * (col + 0.5);
+// Height 0 is the floor, so it is the *last* of the six rows on screen.
+const c404y = (height) => C404_ORIGIN.y + C404_CELL * (5 - height + 0.5);
+
+const Connect404Artwork = () => {
+  const discs = C404_COLUMNS.flatMap((column, col) =>
+    column.map((color, height) => ({
+      color,
+      cx: c404x(col),
+      cy: c404y(height),
+      key: `${col}-${height}`,
+    })),
+  );
+
+  return (
+    <svg viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+      {/* The plate is a solid sheet with forty-two holes punched through it, so
+          the discs below show through exactly as they do in the real thing. */}
+      <mask id="connect404-holes">
+        <rect fill="#ffffff" height="252" rx="10" width="294" x="3" y="48" />
+        {C404_COLUMNS.map((_, col) =>
+          [0, 1, 2, 3, 4, 5].map((height) => (
+            <circle
+              cx={c404x(col)}
+              cy={c404y(height)}
+              fill="#000000"
+              key={`${col}-${height}`}
+              r="16"
+            />
+          )),
+        )}
+      </mask>
+
+      {/* Nobody's turn yet — the disc waiting above the column it would fall
+          down. Drawn first so the plate crops nothing of it. */}
+      <circle cx={c404x(5)} cy="24" fill={C404_FILL.red} opacity="0.35" r="15" />
+
+      {discs.map(({ color, cx, cy, key }) => (
+        <circle cx={cx} cy={cy} fill={C404_FILL[color]} key={key} r="15" />
+      ))}
+
+      <rect
+        fill="rgba(173, 214, 255, 0.15)"
+        height="252"
+        mask="url(#connect404-holes)"
+        rx="10"
+        width="294"
+        x="3"
+        y="48"
+      />
+
+      <line
+        stroke="#ffd700"
+        strokeLinecap="round"
+        strokeWidth="7"
+        x1={c404x(C404_WIN[0])}
+        x2={c404x(C404_WIN[C404_WIN.length - 1])}
+        y1={c404y(0)}
+        y2={c404y(0)}
+      />
+    </svg>
+  );
+};
+
 export default function Page() {
   return (
     <Section>
@@ -328,6 +422,18 @@ export default function Page() {
               <Module>Play</Module>
               <br />
               Edge Case
+            </div>
+          </CardTitle>
+        </Card>
+        <Card className="connect404" href="/games/connect-404">
+          <CardArtwork aria-hidden="true" className="artwork">
+            <Connect404Artwork />
+          </CardArtwork>
+          <CardTitle>
+            <div>
+              <Module>Play</Module>
+              <br />
+              Connect 404
             </div>
           </CardTitle>
         </Card>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -134,6 +134,7 @@ export const Nav = () => {
           <NavLink href="/games/hashtag">Hashtag</NavLink>
           <NavLink href="/games/tic-tac-overflow">Tic-Tac-Overflow</NavLink>
           <NavLink href="/games/edge-case">Edge Case</NavLink>
+          <NavLink href="/games/connect-404">Connect 404</NavLink>
           {/* Mini Motorways is unlinked for now. The page is still served at
               /games/mini-motorways — this only hides the way in. */}
         </Menu>

--- a/src/lib/realtime/registry.js
+++ b/src/lib/realtime/registry.js
@@ -1,3 +1,4 @@
+import { connect404 } from "@/app/(pages)/games/connect-404/multiplayer";
 import { edgeCase } from "@/app/(pages)/games/edge-case/multiplayer";
 import { ticTacOverflow } from "@/app/(pages)/games/tic-tac-overflow/multiplayer";
 
@@ -18,6 +19,7 @@ import { unknownGame } from "./errors";
 const GAMES = [
   ticTacOverflow, // "tto"       -> #88
   edgeCase, //       "edge-case" -> #89
+  connect404, //     "connect-404" -> #111
 ];
 
 for (const def of GAMES) registerGame(def);


### PR DESCRIPTION
Closes #114. Part of #111, on top of the engine (#112) and the board (#113) — base is `feat/111-connect-404`.

Connect 404 gets a front door and a second player. The board and the rules are untouched; this is the mode picker, the room, the multiplayer registration, and the two places on the site that link to the game.

## The mode picker

`Connect404.jsx` is three screens and one page: the picker, the hotseat game (`ContextProvider` + `Game`, byte for byte what #113 shipped), and the same board driven by a room. Which one is showing is client state rather than a route — a board is not something you want to navigate back into by accident.

**Same device issues no request at all.** Verified rather than assumed: a full hotseat game to a win, then `performance.getEntriesByType("resource")` — zero `/api/rooms` entries, the only API call on the page being NextAuth's session.

`?room=CODE` deep-links into a room, read in an effect after mount because the page is prerendered. "Back to the menu" strips the parameter, or a reload would bounce straight back in.

## The server's authority is the engine's reducer

`multiplayer.js` is an adapter, not a second rulebook. It restates nothing and adds exactly two things:

- **`NEW GAME`**, which the engine has no opinion about because a rematch is a room-level event rather than a move. It goes through the engine's own `resetState`, which is where "the winner opens the next game" already lives — so a rematch is one action and no lobby round trip, and either player may ask for it.
- **Flattening the refusal.** `_lib` reports `{ code, message }` so a caller can branch on the code; `rooms.js` passes whatever it gets to `rejected(message, …)` and serialises it. Hand the object through unchanged and the browser renders an object into a `<div>`.

`createState` deliberately ignores the roster the core hands it. `_lib/createState` **throws** on anything but exactly two slots, and a room is created with one player in it — so the seats are the fixed array `[0, 1]` and the second one fills when somebody joins. Red is seat 0, blue is seat 1: colour is a seat here, not a preference, so the definition offers an empty palette rather than storing a second answer that could disagree with `players.js`.

## One board, two providers

`OnlineGame` fills the same context shape the hotseat provider does — `{ state: { game, players }, dispatch, online }` — so the board, the turn banner and the endgame panel are shared verbatim. The cast comes from the same `createPlayers`, so the strip's "You are Red" and the discs on the board cannot end up disagreeing. `online.youSlot` is the one fact `Game` needs to close the board on the other player's turn; a spectator is `null` and nothing is live.

A drop crosses the wire **without** the slot the local action carries. The server resolves who moved from the token, and a slot in a request body is a slot somebody can lie about. A 409 is retried exactly once — the opponent's move landed between the render we tapped and the request we sent, and `send` has already applied the board we missed; a second failure means the column really is contested.

Leaving, presence and departure notices go through `absence.js` like the other two games, and a dead room gets "Connection lost — a game closes after an hour without a move", not a spinner.

## Site integration

A fifth card needs a fifth column. Past 1296px the grid is now five equal portraits rather than four with a double-width Edge Case — that column only ever looked square because the row was as tall as the 1:2 cards beside it, and it stops being square the moment anything changes around it. Below that breakpoint Connect 404 stacks as a 2:1 band like Edge Case does.

The art is drawn in SVG in the site palette, as the neighbouring tiles are: a 7x6 plate with forty-two holes **masked** out of it so the discs show through the way they do in the real thing, red taking the bottom row under a gold winning line, and a ghost disc hanging over an empty column — because a turn here is a column, not a square. The columns in the source are written bottom-up, the same way round the engine stores them.

Nav gets Connect 404 under **Play**.

## Verified, against the real database

Local MySQL (`csalinas-dev-mysql`), dev server on 3082, two browser tabs with distinct tokens.

- **Hotseat**: full game to a win, **zero** `/api/rooms` requests.
- **Online**: create → 4-char code → join by code → full game to a Blue win. Moves propagate in about two seconds; the non-mover's columns carry `aria-disabled` and a click on one produces no request.
- **Bypassing the UI**: posting a drop out of turn is `422 "It is not your turn."`; the same request with `slot: 1` and `playerId: 1` in the body and `slot: 1` in the action is refused identically, because the body has no say; a token holding no seat is `403 not-a-player`. Board and revision untouched in all three.
- **Winner goes first**: the *loser* pressed Play again and the board came back with the winner on the clock, their columns open and the loser's closed.
- **Deep link**: `?room=CODE` rejoined the same seat.
- **Departure**: one tab left, the other said "Player 2 left the game." with a way out.
- **Death**: deleting the room row mid-game turned the stream into "Connection lost"; an unknown code gets its own sentence.
- **Index and nav** both show Connect 404 and both navigate to it.
- A scripted API pass over the same route (create → join → win → rematch → stale revision → off-board column → unknown action → unknown room) ran 40 assertions, all green — including one asserting the 422 `message` is a string rather than the engine's error object.

`npm run lint` and `npm run build` are clean.

## Notes for review

- `components/Button.jsx` and `components/Panel.jsx` are new files in #113's directory. The chrome around the board — the picker, the join form, the waiting room, a lost connection — needs them, and both Tic-Tac-Overflow and Edge Case keep exactly these two there. `components/index.js` is the only shared file touched, and only to add two exports.
- `page.js` keeps #113's metadata with one clause changed: the description said "two players on one device", which is now half the story.
- Nothing under `src/lib/realtime/` changed except the one import and one line in `registry.js` that every game adds.
- The spectator path (a third browser degraded to watching) is wired and reads correctly but was **not** exercised in a browser — it is the core's own behaviour and is covered by the other two games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
