### PR TITLE
Connect 404: Connect Four, offline and online

### DIFF
--- a/src/app/(pages)/games/connect-404/Connect404.jsx
+++ b/src/app/(pages)/games/connect-404/Connect404.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ContextProvider } from "./context";
+import Game from "./Game";
+
+/**
+ * Connect 404 — the page.
+ *
+ * One screen for now: the hotseat game, two players and one device. Online play
+ * and the mode picker in front of it are #114's, and they replace the body of
+ * this component rather than anything under it — `Game` and the board already
+ * take their state from a context that does not care who fills it.
+ */
+export const Connect404 = () => (
+  <ContextProvider>
+    <Game />
+  </ContextProvider>
+);
+
+export default Connect404;

--- a/src/app/(pages)/games/connect-404/Connect404.jsx
+++ b/src/app/(pages)/games/connect-404/Connect404.jsx
@@ -1,20 +1,69 @@
 "use client";
 
-import { ContextProvider } from "./context";
-import Game from "./Game";
+import { useCallback, useEffect, useState } from "react";
 
-/**
- * Connect 404 — the page.
- *
- * One screen for now: the hotseat game, two players and one device. Online play
- * and the mode picker in front of it are #114's, and they replace the body of
- * this component rather than anything under it — `Game` and the board already
- * take their state from a context that does not care who fills it.
- */
-export const Connect404 = () => (
-  <ContextProvider>
-    <Game />
-  </ContextProvider>
-);
+import { isValidCode, normalizeCode } from "@/lib/realtime/codes";
+
+import Game from "./Game";
+import { Lobby } from "./Lobby";
+import { ContextProvider } from "./context";
+import { OnlineGame } from "./online";
+
+// Three screens, one page.
+//
+//   null     the mode picker
+//   "local"  the hotseat game — its own useReducer, no room, no hook, no
+//            request. The realtime core is not in this branch at all, which is
+//            what lets two people on a sofa play with the network switched off.
+//   "online" the same board driven by a room.
+//
+// Which one is showing is client state rather than a route: the board is not
+// something you want to navigate back into by accident, and the local game has
+// never had a URL of its own.
+
+export const Connect404 = () => {
+  const [mode, setMode] = useState(null);
+  const [code, setCode] = useState(null);
+
+  // A shared link (?room=K7F2) drops straight into that room. Read after mount
+  // rather than during render: this page is prerendered, so the first client
+  // render has to match the server's markup.
+  useEffect(() => {
+    const shared = normalizeCode(
+      new URLSearchParams(window.location.search).get("room") ?? "",
+    );
+    if (isValidCode(shared)) {
+      setCode(shared);
+      setMode("online");
+    }
+  }, []);
+
+  const play = useCallback((joined) => {
+    setCode(joined);
+    setMode("online");
+  }, []);
+
+  const leave = useCallback(() => {
+    setMode(null);
+    setCode(null);
+    // Drop ?room= as well, or "back to the menu" would bounce straight back in
+    // on the next reload.
+    window.history.replaceState(null, "", window.location.pathname);
+  }, []);
+
+  if (mode === "local") {
+    return (
+      <ContextProvider>
+        <Game />
+      </ContextProvider>
+    );
+  }
+
+  if (mode === "online" && code) {
+    return <OnlineGame code={code} onLeave={leave} />;
+  }
+
+  return <Lobby onOnline={play} onSameDevice={() => setMode("local")} />;
+};
 
 export default Connect404;

--- a/src/app/(pages)/games/connect-404/Game.jsx
+++ b/src/app/(pages)/games/connect-404/Game.jsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useContext, useMemo } from "react";
+import styled from "@emotion/styled";
+
+import { getResult } from "./_lib";
+import { Board } from "./board";
+import { Announcer, Endgame, TurnBanner } from "./components";
+import { Context, dropPiece, newGame } from "./context";
+import { playerFor } from "./players";
+import { Toolbar } from "./Toolbar";
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  justify-content: flex-start;
+  padding: 3.5rem 1rem 1.5rem;
+  position: relative;
+  width: 100%;
+`;
+
+// One column, capped where a seven-wide board's columns are still a comfortable
+// thumb apart and a phone gets the whole thing edge to edge.
+const Stack = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.75rem;
+  max-width: 30rem;
+  width: 100%;
+`;
+
+/**
+ * The game — the wiring between the store and the board.
+ *
+ * Everything the board needs is computed here and passed down, which is the
+ * whole point: this file does not know or care where its state came from. The
+ * hotseat provider fills the context from a `useReducer`; an online game (#114)
+ * fills the identical shape from a room. The only difference either makes is
+ * the pair of facts below — which slot this device plays, and whether it may
+ * move — and the board does not change by a line between them.
+ *
+ * @param {Object} props
+ * @param {React.ReactNode} [props.banner] - Rendered above the board. An online
+ *   game puts its room strip here.
+ */
+export default function Game({ banner }) {
+  const { state, dispatch, online } = useContext(Context);
+  const { game, players } = state;
+
+  const result = useMemo(() => getResult(game), [game]);
+
+  // Hotseat: the device belongs to whoever is up. Online: to the seat this
+  // browser holds — resolved by the server from its token — and only while the
+  // clock is on that seat. A spectator has no seat, so `youSlot` is null and
+  // nothing on the board is live.
+  const youSlot = online ? online.youSlot : game.turn;
+  const interactive = online
+    ? youSlot !== null && youSlot === game.turn && !game.finished
+    : !game.finished;
+
+  // Whose name the banner says is on the clock. NOT `youSlot`: on one device
+  // they are the same player and online they are usually not, and a banner that
+  // reads "Blue to move" while Red is thinking is worse than no banner.
+  const mover = playerFor(players, game.turn);
+
+  const onDrop = useCallback(
+    (col) => dispatch(dropPiece(col, youSlot)),
+    [dispatch, youSlot]
+  );
+
+  const onPlayAgain = useCallback(() => dispatch(newGame()), [dispatch]);
+
+  return (
+    <Container>
+      <Toolbar
+        cells={result.cells}
+        moves={result.moves}
+        /* Online there is no mid-game restart — a shared board is not one
+           player's to wipe — so the rematch lives in the endgame panel and
+           this button is simply absent. */
+        onRestart={online ? null : onPlayAgain}
+      />
+
+      <Stack>
+        {banner}
+
+        <TurnBanner game={game} player={mover} />
+
+        <Board
+          game={game}
+          interactive={interactive}
+          onDrop={onDrop}
+          players={players}
+          youSlot={youSlot}
+        />
+
+        {result.finished && (
+          <Endgame
+            game={game}
+            onPlayAgain={onPlayAgain}
+            winner={
+              result.winner === null ? null : playerFor(players, result.winner)
+            }
+          />
+        )}
+      </Stack>
+
+      <Announcer game={game} players={players} />
+    </Container>
+  );
+}

--- a/src/app/(pages)/games/connect-404/Lobby.jsx
+++ b/src/app/(pages)/games/connect-404/Lobby.jsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import styled from "@emotion/styled";
+
+import { isValidCode, normalizeCode } from "@/lib/realtime/codes";
+import { CODE_LENGTH } from "@/lib/realtime/constants";
+import { createRoom } from "@/lib/realtime/useRoom";
+
+import {
+  Button,
+  Panel,
+  PanelActions,
+  PanelError,
+  PanelHeading,
+  PanelText,
+} from "./components";
+import { C404_GAME_ID } from "./multiplayer";
+
+// The front door. Two ways to play and nothing else on screen, because the only
+// decision here is whether the other player is sitting next to you.
+//
+// Nothing on this screen touches the network until somebody chooses Online —
+// "Same device" is a state change and not a request, which is what keeps the
+// hotseat game playable with no server at all.
+
+const Choices = styled.div`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+  width: min(100%, 26rem);
+
+  @media (min-width: 600px) {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+
+const Choice = styled(Button)`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.35rem;
+  padding: 1.25rem 1rem;
+  text-align: center;
+`;
+
+const ChoiceTitle = styled.span`
+  font-size: 1.1rem;
+`;
+
+const ChoiceHint = styled.span`
+  color: var(--absentForeground);
+  font-size: 0.85rem;
+  line-height: 1.15rem;
+`;
+
+const Form = styled.form`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 1rem;
+`;
+
+const CodeInput = styled.input`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--absentForeground);
+  border-radius: 0.5rem;
+  color: var(--parenthesis);
+  font-family: inherit;
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  padding: 0.5rem 0 0.5rem 0.3em;
+  text-align: center;
+  text-transform: uppercase;
+  width: min(100%, 15rem);
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+export const Lobby = ({ onOnline, onSameDevice }) => {
+  // "pick" is the two-way choice; "join" is the code form. Creating a room has
+  // no screen of its own — it is one request and then you are in the room.
+  const [view, setView] = useState("pick");
+  const [entry, setEntry] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  const create = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+
+    const result = await createRoom({ game: C404_GAME_ID });
+    if (result.ok) {
+      onOnline(result.code);
+      return;
+    }
+
+    setBusy(false);
+    setError(result.message ?? "Could not start a game. Try again in a moment.");
+  }, [onOnline]);
+
+  const join = useCallback(
+    (event) => {
+      event.preventDefault();
+      const code = normalizeCode(entry);
+      if (!isValidCode(code)) {
+        setError(`A game code is ${CODE_LENGTH} letters and numbers.`);
+        return;
+      }
+      // Whether the room is actually there is the room screen's question; it
+      // already has to answer it for a game that expires mid-session.
+      onOnline(code);
+    },
+    [entry, onOnline],
+  );
+
+  if (view === "join") {
+    return (
+      <Panel>
+        <PanelHeading>Join a game</PanelHeading>
+        <PanelText>Type the code the other player is looking at.</PanelText>
+        <Form onSubmit={join}>
+          <CodeInput
+            aria-label="Game code"
+            autoCapitalize="characters"
+            autoComplete="off"
+            autoCorrect="off"
+            autoFocus
+            maxLength={CODE_LENGTH}
+            onChange={(event) => {
+              setEntry(normalizeCode(event.target.value));
+              setError(null);
+            }}
+            spellCheck="false"
+            value={entry}
+          />
+          {error && <PanelError>{error}</PanelError>}
+          <PanelActions>
+            <Button
+              onClick={() => {
+                setView("pick");
+                setError(null);
+              }}
+              type="button"
+            >
+              Back
+            </Button>
+            <Button disabled={entry.length < CODE_LENGTH} type="submit">
+              Join game
+            </Button>
+          </PanelActions>
+        </Form>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel>
+      <PanelHeading>Connect 404</PanelHeading>
+      <PanelText>
+        Drop a piece down one of seven columns. Four in a row — across, up or
+        diagonally — wins.
+      </PanelText>
+
+      <Choices>
+        <Choice onClick={onSameDevice} type="button">
+          <ChoiceTitle>
+            <span>
+              <i className="fa-solid fa-mobile-screen" />
+            </span>{" "}
+            Same device
+          </ChoiceTitle>
+          <ChoiceHint>Pass it back and forth. No connection needed.</ChoiceHint>
+        </Choice>
+        <Choice disabled={busy} onClick={create} type="button">
+          <ChoiceTitle>
+            <span>
+              <i className="fa-solid fa-globe" />
+            </span>{" "}
+            {busy ? "Starting…" : "Play online"}
+          </ChoiceTitle>
+          <ChoiceHint>
+            Get a code to share with somebody anywhere else.
+          </ChoiceHint>
+        </Choice>
+      </Choices>
+
+      {error && <PanelError>{error}</PanelError>}
+
+      <PanelActions>
+        <Button onClick={() => setView("join")} type="button">
+          I have a code
+        </Button>
+      </PanelActions>
+    </Panel>
+  );
+};
+
+export default Lobby;

--- a/src/app/(pages)/games/connect-404/Toolbar.jsx
+++ b/src/app/(pages)/games/connect-404/Toolbar.jsx
@@ -1,0 +1,87 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  display: flex;
+  flex-flow: row nowrap;
+  font-size: 1rem;
+  gap: 0.5rem;
+  left: 0;
+  line-height: 1rem;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  @media (max-width: 600px) {
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+  }
+`;
+
+// The game's name is the longest thing here and the page title already says it,
+// so it is the first thing to go when the toolbar runs out of room.
+const Name = styled.div`
+  flex: 1 1 auto;
+  white-space: nowrap;
+
+  @media (max-width: 480px) {
+    display: none;
+  }
+`;
+
+const Progress = styled.div`
+  color: var(--absentForeground);
+  flex: 1 1 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+`;
+
+const Action = styled.button`
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.35rem;
+  color: var(--component);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: inherit;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
+  white-space: nowrap;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * The strip across the top of the board.
+ *
+ * The action is optional, and a null handler means the button is not there at
+ * all rather than there and inert. Online there is no "restart" mid-game: a
+ * shared board is not one player's to wipe.
+ */
+export const Toolbar = ({ cells, moves, onRestart }) => (
+  <Container>
+    <Name>Connect 404</Name>
+    <Progress>
+      {moves} / {cells} pieces
+    </Progress>
+    {onRestart && (
+      <Action onClick={onRestart} type="button">
+        {/* The Font Awesome kit replaces this <i> with an <svg> after mount, so
+            it lives in a wrapper React owns — otherwise unmounting a button
+            React no longer recognises throws. */}
+        <span>
+          <i className="fa-solid fa-rotate-left" />
+        </span>{" "}
+        Restart
+      </Action>
+    )}
+  </Container>
+);

--- a/src/app/(pages)/games/connect-404/_lib/board.js
+++ b/src/app/(pages)/games/connect-404/_lib/board.js
@@ -1,0 +1,130 @@
+/**
+ * Connect 404 — board geometry.
+ *
+ * ┌───────────────────────────────────────────────────────────────────────────┐
+ * │ COORDINATE CONVENTION — read this before rendering, hit-testing or        │
+ * │ animating. Do not re-derive it; three renderers disagreeing about which   │
+ * │ end of a column is the floor is three different bugs.                     │
+ * └───────────────────────────────────────────────────────────────────────────┘
+ *
+ * ROW 0 IS THE BOTTOM. `col` grows RIGHTWARD, `row` grows UPWARD.
+ *
+ * The board is stored COLUMN-MAJOR as `state.columns`: one array per column,
+ * holding only the pieces actually in it. `columns[c][0]` is the piece resting
+ * on the floor of column c, and a new piece is PUSHED ON TOP. That is gravity,
+ * expressed as `Array.prototype.push` — a column is always a contiguous stack
+ * from the bottom, and a floating piece is unrepresentable rather than merely
+ * illegal.
+ *
+ * A column's LENGTH is therefore both its height and the row a new piece would
+ * land on, which is all `landingRow` is.
+ *
+ *          col  0   1   2   3   4   5   6
+ *              ┌───┬───┬───┬───┬───┬───┬───┐
+ *      row 5   │   │   │   │   │   │   │   │   ← TOP    (columns[c][5])
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 4   │   │   │   │   │   │   │   │
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 3   │   │   │   │   │   │   │   │
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 2   │   │   │ B │   │   │   │   │   columns[2] = [A, R, B]
+ *              ├───┼───┼───┼───┼───┼───┼───┤              length 3
+ *      row 1   │   │ R │ R │   │   │   │   │              landingRow = 3
+ *              ├───┼───┼───┼───┼───┼───┼───┤
+ *      row 0   │ R │ A │ A │   │   │   │   │   ← BOTTOM (columns[c][0])
+ *              └───┴───┴───┴───┴───┴───┴───┘
+ *                                 ▲
+ *                                 └── columns[4] = [], landingRow = 0
+ *
+ * A CELL is the pair `[col, row]`, in that order — the same order `lastMove`
+ * and every entry of `winningLine` use. `cellAt(state, col, row)` is the slot
+ * occupying it, or null.
+ *
+ * Rendering top-down (which is how a board is drawn) means walking rows
+ * DESCENDING: `for (let row = rows - 1; row >= 0; row -= 1)`. Do not flip the
+ * stored data to make a render loop read nicer; flip the loop.
+ *
+ * Every helper below takes a `board`: any object carrying `cols`, `rows` and
+ * `columns`. A game state is a valid board, so `landingRow(state, 3)` works
+ * as-is.
+ */
+
+/** Whether `col` names a column this board actually has. */
+export const isColumnInRange = ({ cols }, col) =>
+  Number.isInteger(col) && col >= 0 && col < cols;
+
+/** Whether `row` names a row this board actually has. */
+export const isRowInRange = ({ rows }, row) =>
+  Number.isInteger(row) && row >= 0 && row < rows;
+
+/**
+ * How many pieces are stacked in a column.
+ * @param {Object} board - Anything with `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Number} 0…rows, and 0 for a column that does not exist
+ */
+export const columnHeight = ({ columns }, col) => columns[col]?.length ?? 0;
+
+/**
+ * Whether a column has no room left.
+ * @param {Object} board - Anything with `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Boolean} True when the column is full
+ */
+export const isColumnFull = (board, col) =>
+  columnHeight(board, col) >= board.rows;
+
+/**
+ * The row a piece dropped into this column would come to rest on.
+ *
+ * This is what the hover preview and the drop animation both read, so it has
+ * to agree exactly with where `dropPiece` actually puts the piece — it is the
+ * same expression in both places, deliberately.
+ *
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @returns {Number|null} The landing row (0 = bottom), or null if the column
+ *   is full or is not on this board
+ */
+export const landingRow = (board, col) => {
+  if (!isColumnInRange(board, col)) return null;
+
+  const height = columnHeight(board, col);
+
+  return height < board.rows ? height : null;
+};
+
+/**
+ * Who occupies a cell.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column index, 0…cols - 1
+ * @param {Number} row - Row index, 0 = BOTTOM
+ * @returns {String|Number|null} The slot resting there, or null when the cell
+ *   is empty or off the board
+ */
+export const cellAt = (board, col, row) => {
+  if (!isColumnInRange(board, col) || !isRowInRange(board, row)) return null;
+
+  return board.columns[col][row] ?? null;
+};
+
+/** How many cells the board has in total. */
+export const cellCount = ({ cols, rows }) => cols * rows;
+
+/** How many pieces have been played — which is also how many moves were made. */
+export const pieceCount = ({ columns }) =>
+  columns.reduce((total, column) => total + column.length, 0);
+
+/** Whether every cell is occupied. */
+export const isBoardFull = (board) =>
+  pieceCount(board) >= cellCount(board);
+
+/**
+ * The columns a piece can still be dropped into.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @returns {Number[]} Column indices, left to right
+ */
+export const openColumns = (board) =>
+  Array.from({ length: board.cols }, (unused, col) => col).filter(
+    (col) => !isColumnFull(board, col)
+  );

--- a/src/app/(pages)/games/connect-404/_lib/constants.js
+++ b/src/app/(pages)/games/connect-404/_lib/constants.js
@@ -1,0 +1,32 @@
+/**
+ * Connect 404 — shared constants.
+ *
+ * "Four in a row. Nothing found."
+ */
+
+// A standard Connect Four board: 7 columns wide, 6 rows tall, 42 cells.
+export const COLS = 7;
+export const ROWS = 6;
+
+// How many in a row wins. Named rather than inlined because the win scan reads
+// it four times and an off-by-one there is invisible until someone wins early.
+export const CONNECT = 4;
+
+// Connect Four is strictly two-handed — gravity and a 7x6 board only divide
+// two ways — so `slots` is always exactly this long.
+export const MIN_PLAYERS = 2;
+export const MAX_PLAYERS = 2;
+
+// Every reason a move can be rejected. `dropPiece` never throws for a bad
+// move — it returns the unchanged state (same reference) plus one of these.
+export const MoveError = Object.freeze({
+  Finished: "finished",
+  UnknownSlot: "unknown-slot",
+  NotYourTurn: "not-your-turn",
+  OutOfRange: "out-of-range",
+  ColumnFull: "column-full",
+  UnknownAction: "unknown-action",
+});
+
+// The action type the shared realtime core dispatches at `reducer`.
+export const DROP_PIECE = "DROP PIECE";

--- a/src/app/(pages)/games/connect-404/_lib/createState.js
+++ b/src/app/(pages)/games/connect-404/_lib/createState.js
@@ -1,0 +1,73 @@
+import { COLS, MAX_PLAYERS, MIN_PLAYERS, ROWS } from "./constants";
+
+const isSlot = (slot) =>
+  (typeof slot === "string" && slot.length > 0) || Number.isInteger(slot);
+
+/**
+ * A fresh board.
+ *
+ * Unlike `dropPiece`, this throws: a bad player list is a programming error in
+ * the lobby, not a move a player can make, and it must not produce a
+ * half-valid board the rest of the engine then has to defend against.
+ *
+ * @param {Object} options
+ * @param {(String|Number)[]} options.slots - The two player slots, in JOIN
+ *   ORDER. Turns rotate through this ARRAY — never through `Object.keys` of
+ *   anything, because a room's state is a MySQL JSON column and MySQL does not
+ *   preserve object key order. A turn order derived from key order passes every
+ *   local test and scrambles only online games.
+ * @param {String|Number} [options.first] - Who moves first. Defaults to
+ *   `slots[0]`; pass the previous winner so they open the next game.
+ * @returns {Object} A game state
+ */
+export const createState = ({ slots, first } = {}) => {
+  if (!Array.isArray(slots) || !slots.every(isSlot)) {
+    throw new Error(
+      "Connect 404: slots must be an array of non-empty strings or integers"
+    );
+  }
+
+  if (slots.length < MIN_PLAYERS || slots.length > MAX_PLAYERS) {
+    throw new Error(
+      `Connect 404: a game needs exactly ${MAX_PLAYERS} players, got ${slots.length}`
+    );
+  }
+
+  if (new Set(slots).size !== slots.length) {
+    throw new Error("Connect 404: slots must be unique");
+  }
+
+  if (first !== undefined && !slots.includes(first)) {
+    throw new Error("Connect 404: `first` must be one of the slots");
+  }
+
+  return {
+    cols: COLS,
+    rows: ROWS,
+    // Column-major stacks, bottom-first: `columns[c][0]` sits on the floor.
+    // See the coordinate convention at the top of `board.js`.
+    columns: Array.from({ length: COLS }, () => []),
+    // Join order, and the array turn rotation reads. Copied so the caller's
+    // roster and the board's running order cannot drift apart later.
+    slots: [...slots],
+    turn: first ?? slots[0],
+    lastMove: null,
+    winner: null,
+    winningLine: null,
+    draw: false,
+    finished: false,
+  };
+};
+
+/**
+ * The same two players, back at move one — the "play again" button.
+ *
+ * The winner opens the next game, which is the convention every one of these
+ * games uses. A draw has no winner to hand the first move to, so it goes back
+ * to join order.
+ *
+ * @param {Object} state - A finished (or abandoned) game state
+ * @returns {Object} A fresh game state with the same players
+ */
+export const resetState = ({ slots, winner }) =>
+  createState({ slots, first: winner ?? slots[0] });

--- a/src/app/(pages)/games/connect-404/_lib/dropPiece.js
+++ b/src/app/(pages)/games/connect-404/_lib/dropPiece.js
@@ -1,0 +1,84 @@
+import { MoveError } from "./constants";
+import { isBoardFull, isColumnFull, isColumnInRange, landingRow } from "./board";
+import { findWinningLine } from "./winningLine";
+
+const MESSAGES = {
+  [MoveError.Finished]: "The game is already over.",
+  [MoveError.UnknownSlot]: "You are not in this game.",
+  [MoveError.NotYourTurn]: "It is not your turn.",
+  [MoveError.OutOfRange]: "That column is not on this board.",
+  [MoveError.ColumnFull]: "That column is full.",
+  [MoveError.UnknownAction]: "Connect 404 does not know that action.",
+};
+
+// A rejected move leaves the state exactly as it was — SAME REFERENCE, so
+// callers can `if (result.state === state)` and skip a re-render.
+export const reject = (state, code) => ({
+  state,
+  error: { code, message: MESSAGES[code] },
+});
+
+// The next player in join order, wrapping. Reads the `slots` ARRAY; see the
+// note in `createState`.
+const nextTurn = ({ slots, turn }) =>
+  slots[(slots.indexOf(turn) + 1) % slots.length];
+
+/**
+ * Drop a piece into a column.
+ *
+ * Gravity is the whole game: a player picks a column, never a cell, and the
+ * piece lands on top of whatever is already there. `landingRow` reports that
+ * row for the hover preview, and this uses the same function to place it, so
+ * the ghost piece and the real one can never disagree.
+ *
+ * Pure and synchronous, so the server and every client can run it on the same
+ * state and land on the same board.
+ *
+ * @param {Object} state - The current game state
+ * @param {Number} col - The column to drop into, 0…cols - 1
+ * @param {String|Number} slot - The player attempting the move
+ * @returns {{state: Object, error?: {code: String, message: String}}} The next
+ *   state, or the untouched state and a reason it was rejected
+ */
+export const dropPiece = (state, col, slot) => {
+  const { columns, slots, turn } = state;
+
+  if (state.finished) return reject(state, MoveError.Finished);
+  if (!slots.includes(slot)) return reject(state, MoveError.UnknownSlot);
+  if (slot !== turn) return reject(state, MoveError.NotYourTurn);
+  if (!isColumnInRange(state, col)) return reject(state, MoveError.OutOfRange);
+  if (isColumnFull(state, col)) return reject(state, MoveError.ColumnFull);
+
+  const row = landingRow(state, col);
+
+  // Only the one column changes; the other six arrays are shared, which keeps
+  // a per-column memo in the renderer honest.
+  const nextColumns = [...columns];
+  nextColumns[col] = [...columns[col], slot];
+
+  const board = { ...state, columns: nextColumns };
+
+  // A win can only run through the piece that just landed, so that is the only
+  // cell worth scanning from.
+  const winningLine = findWinningLine(board, col, row);
+  const winner = winningLine ? slot : null;
+
+  // A full board with no line is a DRAW: a real, third outcome. It is not a
+  // loss for whoever filled the last cell, and it is not a win for anybody.
+  const draw = winner === null && isBoardFull(board);
+
+  return {
+    state: {
+      ...board,
+      // The mover stays on the clock once the game is over — there is no next
+      // turn to hand out, and a finished board reads better naming the player
+      // who ended it than the one who never got to reply.
+      turn: winner !== null || draw ? slot : nextTurn(state),
+      lastMove: { col, row, slot },
+      winner,
+      winningLine,
+      draw,
+      finished: winner !== null || draw,
+    },
+  };
+};

--- a/src/app/(pages)/games/connect-404/_lib/getResult.js
+++ b/src/app/(pages)/games/connect-404/_lib/getResult.js
@@ -1,0 +1,39 @@
+import { cellCount, pieceCount } from "./board";
+
+/**
+ * How the game stands, or how it ended.
+ *
+ * A DRAW is reported as a draw. A full board with no line is a real outcome —
+ * neither player lost it — so `winner` stays null and `draw` is true, and
+ * anything rendering a result must read `draw` before reaching for a name.
+ *
+ * The three end fields are decided by `dropPiece` at the moment the piece
+ * lands and stored on the state, because the online half persists that state
+ * and everybody has to agree on it. This reads them back and adds the counts a
+ * status line wants, rather than re-deciding the game.
+ *
+ * @param {Object} state - A game state, finished or not
+ * @returns {Object} winner, draw, winningLine, finished, turn, moves, cells
+ *   and remaining
+ */
+export const getResult = (state) => {
+  const { draw, finished, turn, winner, winningLine } = state;
+  const moves = pieceCount(state);
+  const cells = cellCount(state);
+
+  return {
+    // Null while the game is live, and null on a draw. `draw` is the field to
+    // read in the second case.
+    winner: winner ?? null,
+    draw: draw === true,
+    // The exact cells to highlight, in board order — four of them, or more on
+    // the rare run of five.
+    winningLine: winningLine ?? null,
+    finished: finished === true,
+    // Whose move it is; on a finished board, whoever played the last piece.
+    turn,
+    moves,
+    cells,
+    remaining: cells - moves,
+  };
+};

--- a/src/app/(pages)/games/connect-404/_lib/index.js
+++ b/src/app/(pages)/games/connect-404/_lib/index.js
@@ -1,0 +1,67 @@
+/**
+ * Connect 404 — the game engine.
+ *
+ * "Four in a row. Nothing found."
+ *
+ * Classic Connect Four. This module is the single source of truth for the
+ * rules: it is pure, synchronous and has no dependencies at all — not even
+ * lodash — so the server and every client run the identical code over the
+ * identical state and never disagree about whose turn it is or who won.
+ * Keep it that way; it has to run anywhere a game state does.
+ *
+ * The state:
+ *
+ *   {
+ *     cols: 7, rows: 6,
+ *     columns,        // 7 column stacks, columns[c][0] is the BOTTOM
+ *     slots,          // the two player slots, in join order — an ARRAY
+ *     turn,           // slot
+ *     lastMove,       // { col, row, slot } | null — row 0 is the bottom
+ *     winner,         // slot | null
+ *     winningLine,    // [[col, row], ...] | null — the cells to highlight
+ *     draw,           // bool
+ *     finished,       // bool — winner or draw
+ *   }
+ *
+ * ROW 0 IS THE BOTTOM, `col` grows rightward and `row` grows upward. The full
+ * coordinate convention every renderer and hit-test depends on is documented at
+ * the top of `board.js`. Read it there; do not re-derive it.
+ *
+ * `slots` is an array, and everything that iterates players reads that array.
+ * Room state round-trips through a MySQL JSON column and MySQL does not
+ * preserve object key order, so a turn order taken from `Object.keys` of
+ * anything would pass every local test and scramble only online games.
+ *
+ * A rejected move returns the state it was given, BY REFERENCE, alongside an
+ * error — never a throw and never a fresh object, so `result.state === state`
+ * is a valid "nothing happened, skip the render".
+ */
+
+export {
+  CONNECT,
+  COLS,
+  DROP_PIECE,
+  MAX_PLAYERS,
+  MIN_PLAYERS,
+  MoveError,
+  ROWS,
+} from "./constants";
+
+export { createState, resetState } from "./createState";
+export { dropPiece } from "./dropPiece";
+export { getResult } from "./getResult";
+export { reducer } from "./reducer";
+export { findWinningLine } from "./winningLine";
+
+export {
+  cellAt,
+  cellCount,
+  columnHeight,
+  isBoardFull,
+  isColumnFull,
+  isColumnInRange,
+  isRowInRange,
+  landingRow,
+  openColumns,
+  pieceCount,
+} from "./board";

--- a/src/app/(pages)/games/connect-404/_lib/reducer.js
+++ b/src/app/(pages)/games/connect-404/_lib/reducer.js
@@ -1,0 +1,36 @@
+import { DROP_PIECE, MoveError } from "./constants";
+import { dropPiece, reject } from "./dropPiece";
+
+/**
+ * The player a dispatch came from, as a slot.
+ *
+ * The shared realtime core hands its reducers a `player` OBJECT (it resolves
+ * the seat from the request's token), while the hotseat game has only a slot.
+ * Both are accepted here so neither caller has to remember which it holds; the
+ * engine itself only ever deals in slots.
+ */
+const slotOf = (player) =>
+  player !== null && typeof player === "object" ? player.slot : player;
+
+/**
+ * The per-game reducer the shared realtime core dispatches into: it takes the
+ * state, one action, and the player who sent it, and hands back the next state
+ * or a reason it was refused. Nothing here touches the network — the core owns
+ * transport, this owns the rules.
+ *
+ * @param {Object} state - The current game state
+ * @param {Object} action - `{ type: "DROP PIECE", col }`
+ * @param {String|Number|Object} player - The slot the action arrived from, or
+ *   the core's player object carrying it
+ * @returns {{state: Object, error?: {code: String, message: String}}} Next state
+ */
+export const reducer = (state, action, player) => {
+  switch (action?.type) {
+    case DROP_PIECE:
+      return dropPiece(state, action.col, slotOf(player));
+    default:
+      return reject(state, MoveError.UnknownAction);
+  }
+};
+
+export default reducer;

--- a/src/app/(pages)/games/connect-404/_lib/winningLine.js
+++ b/src/app/(pages)/games/connect-404/_lib/winningLine.js
@@ -1,0 +1,105 @@
+import { CONNECT } from "./constants";
+import { cellAt } from "./board";
+
+/**
+ * Connect 404 — win detection.
+ *
+ * The reference repo (`csalinas-dev/connect4`) never got here; its README
+ * still lists "determine if/when someone wins" as a TODO. So this is written
+ * from scratch, and it is the part of the engine worth being paranoid about.
+ *
+ * Coordinates are `[col, row]` with ROW 0 AT THE BOTTOM — see `board.js`.
+ *
+ * FOUR AXES, not eight. A line and its reverse are the same line, so each axis
+ * is stored once as a step `[dCol, dRow]` and walked in BOTH directions from
+ * the piece that was just played:
+ *
+ *        ↖ (-1,+1)   ↑ (0,+1)   ↗ (+1,+1)
+ *                  ╲    │    ╱
+ *        ← (-1,0) ──── ● ──── → (+1,0)
+ *                  ╱    │    ╲
+ *        ↙ (-1,-1)   ↓ (0,-1)   ↘ (+1,-1)
+ *
+ *   [1, 0]   horizontal   — ← ●
+ *   [0, 1]   vertical     — the stack the piece is sitting in
+ *   [1, 1]   diagonal ↗   — up and to the right ("/" on screen)
+ *   [1, -1]  diagonal ↘   — down and to the right ("\" on screen)
+ *
+ * Both diagonals. They are two distinct axes, and forgetting the second is the
+ * classic Connect Four bug: every test you happen to write passes and the
+ * board silently plays past a real win.
+ */
+const AXES = Object.freeze([
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1],
+]);
+
+/**
+ * How far the same slot continues from a cell in one direction.
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Starting column (not counted)
+ * @param {Number} row - Starting row (not counted)
+ * @param {Number} dCol - Column step, -1 | 0 | 1
+ * @param {Number} dRow - Row step, -1 | 0 | 1
+ * @param {String|Number} slot - The slot to match
+ * @returns {Number} How many consecutive matching cells lie that way
+ */
+const runLength = (board, col, row, dCol, dRow, slot) => {
+  let count = 0;
+  let c = col + dCol;
+  let r = row + dRow;
+
+  // `cellAt` returns null off the board, so the edge stops the walk on its own
+  // and there is no separate bounds check to keep in step with this one.
+  while (cellAt(board, c, r) === slot) {
+    count += 1;
+    c += dCol;
+    r += dRow;
+  }
+
+  return count;
+};
+
+/**
+ * The winning line through a cell, if there is one.
+ *
+ * Only ever called with the cell that was just played: a win cannot appear
+ * anywhere a piece did not just land, so scanning all 42 cells after every
+ * move would be forty-one wasted answers.
+ *
+ * A run longer than four is possible — filling the gap in `● ● _ ● ●` makes
+ * five — and the whole run is returned, not an arbitrary four of it. A board
+ * highlighting only four of five in a row looks like a bug because it is one.
+ *
+ * @param {Object} board - Anything with `cols`, `rows` and `columns`
+ * @param {Number} col - Column of the cell to test
+ * @param {Number} row - Row of the cell to test, 0 = BOTTOM
+ * @returns {Array<[Number, Number]>|null} The cells of the run in board order
+ *   — left to right, or bottom to top for a vertical — or null if no run of
+ *   four passes through the cell
+ */
+export const findWinningLine = (board, col, row) => {
+  const slot = cellAt(board, col, row);
+  if (slot === null) return null;
+
+  for (const [dCol, dRow] of AXES) {
+    const before = runLength(board, col, row, -dCol, -dRow, slot);
+    const after = runLength(board, col, row, dCol, dRow, slot);
+
+    if (before + 1 + after < CONNECT) continue;
+
+    // Walk from the far end of the run back along the axis, so the cells come
+    // out in board order — left to right, and bottom to top for a vertical.
+    const startCol = col - before * dCol;
+    const startRow = row - before * dRow;
+
+    return Array.from({ length: before + 1 + after }, (unused, step) => [
+      startCol + step * dCol,
+      startRow + step * dRow,
+    ]);
+  }
+
+  return null;
+};

--- a/src/app/(pages)/games/connect-404/board/Board.jsx
+++ b/src/app/(pages)/games/connect-404/board/Board.jsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { range } from "lodash";
+import styled from "@emotion/styled";
+
+import { landingRow, pieceCount } from "../_lib";
+import { playerFor } from "../players";
+import { useColumnNavigation } from "../hooks";
+import { reload } from "./animations";
+import { Column } from "./Column";
+import { Piece } from "./Piece";
+import { VisuallyHidden } from "../components/VisuallyHidden";
+
+// How long a refusal stays on screen. Long enough to read, short enough that a
+// player who meant to press the column next door is not waiting on it. Cleared
+// on a timer rather than on `animationend`, because under reduced motion the
+// shake never runs and there is no such event to wait for.
+const REFUSAL_MS = 900;
+
+const Frame = styled.div`
+  /* The panel's inset. The chute above it takes the same one so the piece
+     waiting there lines up with the column it is waiting over. */
+  --pad: 0.45rem;
+
+  margin: 0 auto;
+  max-width: 30rem;
+  width: 100%;
+`;
+
+const Chute = styled.div`
+  padding: 0 var(--pad);
+`;
+
+// Exactly one cell tall, and the same width as the columns underneath, so a
+// piece in it is already in the position the fall starts from.
+const Track = styled.div`
+  aspect-ratio: var(--cols) / 1;
+  position: relative;
+  width: 100%;
+`;
+
+// Carries the piece across the board. Transform only, so following the cursor
+// costs nothing but a composite.
+const Rail = styled.div`
+  aspect-ratio: 1 / 1;
+  left: 0;
+  position: absolute;
+  top: 0;
+  transform: translateX(calc(var(--col) * 100%));
+  transition: transform 150ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  width: calc(100% / var(--cols));
+
+  &.blocked {
+    opacity: 0.3;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+`;
+
+// The reload sits inside the rail rather than on it: both want the `transform`
+// property, and the piece has to be able to arrive and slide across at once.
+const Loaded = styled.div`
+  animation: ${reload} 200ms ease-out both;
+  height: 100%;
+  width: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;
+
+// Nothing here may clip: a falling piece spends most of its animation above the
+// panel, in the chute's airspace and sometimes above that.
+const Surface = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Panel = styled.div`
+  background-color: var(--absentBackground);
+  border: 1px solid var(--selectionBackground);
+  border-radius: 0.75rem;
+  display: grid;
+  gap: 0;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  padding: var(--pad);
+  /* The board owns the gestures that land on it — a drag across the columns
+     must not scroll the page out from under the player. */
+  touch-action: manipulation;
+  width: 100%;
+`;
+
+/**
+ * The Connect 404 board.
+ *
+ * This component owns NO game state. It is handed a state, a cast of players,
+ * which slot this device plays and whether that slot may move right now; it
+ * hands back the column that was chosen. Everything it keeps to itself is
+ * presentation — what the cursor is over, what has focus, which column has just
+ * refused a piece.
+ *
+ * That split is deliberate and load-bearing: the hotseat game passes
+ * `youSlot = game.turn`, and an online room (#114) passes the slot that device
+ * joined as and sends `onDrop` over the wire. A spectator passes `interactive
+ * = false` and a null slot. None of them needs the board to change.
+ *
+ * The animation is the feature, so it is worth saying what it does *not* do:
+ * it does not decide anything. A piece is rendered in the cell the engine put
+ * it in before its first frame runs, and every frame of the fall is an offset
+ * from that cell ending at zero. If the animation were dropped entirely — as it
+ * is under `prefers-reduced-motion` — the board would be in the same place.
+ *
+ * @param {Object} props
+ * @param {Object} props.game - An engine state (see `_lib`)
+ * @param {Object[]} props.players - Player descriptors in join order
+ * @param {?(String|Number)} [props.youSlot] - The slot this device plays, if any
+ * @param {Boolean} props.interactive - Whether this device may move right now
+ * @param {Function} props.onDrop - `(col) => void`
+ * @param {React.ReactNode} [props.overlay] - Rendered over the panel, sized to
+ *   it. A "waiting for the other player" curtain (#114) belongs here. The
+ *   endgame deliberately does not: the four winning pieces are the point of
+ *   winning, and covering them to say so would be a strange thing to do.
+ */
+export const Board = ({
+  game,
+  interactive,
+  onDrop,
+  overlay,
+  players,
+  youSlot,
+}) => {
+  // Hover (mouse) and focus (keyboard) are the same idea — "the column I am
+  // about to commit to" — so they feed one preview. Hover wins when both are
+  // live, because the hand is the thing that just moved.
+  const [hovered, setHovered] = useState(null);
+  const [focused, setFocused] = useState(null);
+
+  // A column that has just been asked for a piece it cannot take. `nonce` is
+  // what makes the second refusal look like a refusal too.
+  const [refused, setRefused] = useState(null);
+  const nonce = useRef(0);
+
+  const onActivate = useCallback(
+    (col) => {
+      if (!interactive) return;
+
+      // Stopped at the tap rather than sent and rejected. The engine refuses a
+      // full column too and is still the authority — but online this would be a
+      // round trip whose only possible answer is the one already on screen.
+      if (landingRow(game, col) === null) {
+        nonce.current += 1;
+        setRefused({ col, id: nonce.current });
+        return;
+      }
+
+      setRefused(null);
+      onDrop(col);
+    },
+    [game, interactive, onDrop]
+  );
+
+  const { activeColumn: tabColumn, onKeyDown, register } = useColumnNavigation(
+    game.cols,
+    onActivate
+  );
+
+  useEffect(() => {
+    if (!refused) return undefined;
+
+    const timer = setTimeout(() => setRefused(null), REFUSAL_MS);
+    return () => clearTimeout(timer);
+  }, [refused]);
+
+  const onHover = useCallback((col) => setHovered(col), []);
+  const onFocus = useCallback((col) => setFocused(col), []);
+  const onBlur = useCallback(() => setFocused(null), []);
+
+  const you = useMemo(
+    () => (youSlot === null || youSlot === undefined ? null : playerFor(players, youSlot)),
+    [players, youSlot]
+  );
+
+  // Every move remounts the piece in the chute, which is what replays its
+  // arrival. Counting pieces rather than watching `lastMove` because a new game
+  // has to reload it too, and a new game has no last move.
+  const played = useMemo(() => pieceCount(game), [game]);
+
+  const previewColumn = hovered ?? focused;
+  const previewing = interactive && you !== null && previewColumn !== null;
+  const previewBlocked =
+    previewing && landingRow(game, previewColumn) === null;
+
+  return (
+    <Frame style={{ "--cols": game.cols }}>
+      {/* Where the piece waits, and where the fall starts from. Decorative: the
+          column buttons underneath say the same thing in words. */}
+      <Chute aria-hidden="true">
+        <Track>
+          {previewing && (
+            <Rail
+              className={previewBlocked ? "blocked" : undefined}
+              style={{ "--col": previewColumn }}
+            >
+              <Loaded key={played}>
+                <Piece player={you} />
+              </Loaded>
+            </Rail>
+          )}
+        </Track>
+      </Chute>
+
+      <Surface>
+        <Panel
+          aria-label={`Connect 404 board, ${game.cols} columns by ${game.rows} rows. Use the left and right arrow keys to choose a column and enter to drop a piece.`}
+          role="group"
+        >
+          {range(game.cols).map((col) => (
+            <Column
+              active={previewColumn === col}
+              col={col}
+              game={game}
+              interactive={interactive}
+              key={col}
+              landingRow={landingRow(game, col)}
+              onActivate={onActivate}
+              onBlur={onBlur}
+              onFocus={onFocus}
+              onHover={onHover}
+              onKeyDown={onKeyDown}
+              players={players}
+              refusedNonce={refused?.col === col ? refused.id : null}
+              register={register(col)}
+              tabIndex={tabColumn === col ? 0 : -1}
+              you={you}
+            />
+          ))}
+        </Panel>
+
+        {overlay}
+      </Surface>
+
+      {/* Assertive, and its own region: a refusal interrupts, which is the one
+          thing the running commentary must never do. */}
+      <VisuallyHidden role="alert">
+        {refused ? `Column ${refused.col + 1} is full.` : ""}
+      </VisuallyHidden>
+    </Frame>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Cell.jsx
+++ b/src/app/(pages)/games/connect-404/board/Cell.jsx
@@ -1,0 +1,129 @@
+import styled from "@emotion/styled";
+
+import { fall, pop } from "./animations";
+import { Piece } from "./Piece";
+
+// One square of the grid: an empty socket punched out of the panel, and — if
+// somebody has played here — a piece sitting in it.
+//
+// No margin, no gap, no border. The pitch between cells has to be exactly one
+// cell height or the drop animation, which counts in cells, lands short. The
+// space between the sockets comes from the sockets being smaller than the
+// cells, not from anything between them.
+const Container = styled.div`
+  aspect-ratio: 1 / 1;
+  position: relative;
+  width: 100%;
+
+  /* The hole. */
+  &::before {
+    background-color: var(--background);
+    border-radius: 50%;
+    box-shadow: inset 0 0.08rem 0.22rem rgba(0, 0, 0, 0.55);
+    content: "";
+    inset: 7%;
+    position: absolute;
+  }
+
+  /* Exactly one cell tall, which is what makes translateY(-100%) mean "one row
+     up" — the piece inside it is smaller, and cannot be measured in rows. */
+  .slot {
+    inset: 0;
+    position: absolute;
+  }
+
+  &.landing .slot {
+    /* Farther is longer, the way a longer fall takes longer. The --drop
+       variable is unitless so it can be multiplied by a time here and by a
+       length in the keyframes. */
+    animation: ${fall} calc(150ms + var(--drop) * 52ms) both;
+  }
+
+  /* Part of the four. The ring is permanent and the swell is a one-off, so the
+     line stays marked long after the animation has finished — and a player who
+     looks up late has still missed nothing. */
+  &.winning {
+    z-index: 2;
+
+    .disc {
+      filter: drop-shadow(0 0 0.4rem var(--slot));
+      animation: ${pop} 620ms ease-out var(--delay) both;
+    }
+
+    circle {
+      stroke: var(--foreground);
+      stroke-width: 1.1;
+    }
+  }
+
+  /* Everything that is not part of the winning line steps back so the line can
+     step forward. Never below the point of being readable. */
+  &.dimmed .disc {
+    opacity: 0.4;
+  }
+
+  .disc {
+    height: 100%;
+    transition: opacity 400ms ease-out 500ms;
+    width: 100%;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.landing .slot,
+    &.winning .disc {
+      animation: none;
+    }
+
+    .disc {
+      transition: none;
+    }
+  }
+`;
+
+/**
+ * A cell.
+ *
+ * Everything it is told comes from the engine. It does not know the rules, it
+ * does not know whose turn it is, and — the important one — it does not decide
+ * where a piece stops. `drop` is the distance from the chute to the row the
+ * engine picked, in cells, and the animation only ever runs *up* from there.
+ *
+ * @param {Object} props
+ * @param {?Object} props.player - Whoever is in this cell, or null
+ * @param {Boolean} props.landing - This is the piece that has just been played
+ * @param {Number} props.drop - How many cells above its cell the piece starts
+ * @param {Number} props.winIndex - Its place along the winning line, or -1
+ * @param {Boolean} props.dimmed - The game is won and this is not part of it
+ */
+export const Cell = ({ dimmed, drop, landing, player, winIndex }) => {
+  const winning = winIndex >= 0;
+
+  const className = [
+    landing && "landing",
+    winning && "winning",
+    dimmed && "dimmed",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Container
+      className={className || undefined}
+      style={{
+        "--drop": drop,
+        // Staggered along the line, and held back long enough that the piece
+        // that completed it has landed before its own cell swells.
+        "--delay": winning ? `${240 + winIndex * 110}ms` : undefined,
+        "--slot": player?.color,
+      }}
+    >
+      {player && (
+        <div className="slot">
+          <div className="disc">
+            <Piece player={player} />
+          </div>
+        </div>
+      )}
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Column.jsx
+++ b/src/app/(pages)/games/connect-404/board/Column.jsx
@@ -1,0 +1,200 @@
+import { range } from "lodash";
+import styled from "@emotion/styled";
+
+import { cellAt } from "../_lib";
+import { playerFor } from "../players";
+import { refuse } from "./animations";
+import { Cell } from "./Cell";
+
+// A whole column is one control. That is how the game is played — you choose a
+// column, not a square — and it also happens to give a phone a tap target six
+// cells tall, which no individual cell would.
+const Container = styled.button`
+  background-color: transparent;
+  border: none;
+  border-radius: 0.5rem;
+  color: inherit;
+  cursor: default;
+  display: block;
+  font: inherit;
+  padding: 0;
+  position: relative;
+  width: 100%;
+
+  &.open {
+    cursor: pointer;
+  }
+
+  &.full {
+    cursor: not-allowed;
+  }
+
+  /* The column under the cursor or the keyboard. Faint, because it is behind
+     six sockets and the piece hovering over it says the same thing louder. */
+  &.active::after {
+    background-color: var(--selectionBackground);
+    border-radius: 0.4rem;
+    content: "";
+    inset: 0;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+// The thing that actually shakes when a full column is asked for another piece.
+// Separate from the button so the refusal never moves the focus ring, and so it
+// can be remounted to replay — which the button, holding focus, must not be.
+const Stack = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  width: 100%;
+
+  &.refused {
+    animation: ${refuse} 380ms ease-in-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &.refused {
+      animation: none;
+    }
+  }
+`;
+
+/**
+ * What is in a column, bottom first.
+ *
+ * Bottom first because that is the order the pieces arrived in and the order
+ * the labels count rows in — a column read top-down would be describing a
+ * board nobody is playing on.
+ *
+ * @returns {String} "empty", or "3 of 6 filled, from the bottom: Red, Blue, Red"
+ */
+const describeContents = (game, players, col) => {
+  const height = game.columns[col].length;
+  if (height === 0) return "empty";
+
+  const names = range(height).map(
+    (row) => playerFor(players, cellAt(game, col, row)).name
+  );
+
+  // A full column says so first and counts afterwards. "6 of 6 filled" is the
+  // same fact arrived at by arithmetic, and it should not be the first thing a
+  // player has to do to find out they cannot play there.
+  const state =
+    height >= game.rows ? "full" : `${height} of ${game.rows} filled`;
+
+  return `${state}, from the bottom: ${names.join(", ")}`;
+};
+
+/**
+ * One column of the board, and the control that drops a piece into it.
+ *
+ * @param {Object} props
+ * @param {Number} props.col - 0-based column
+ * @param {Object} props.game - An engine state
+ * @param {Object[]} props.players - Player descriptors
+ * @param {Boolean} props.active - The cursor or the keyboard is on this column
+ * @param {Boolean} props.interactive - This device may drop a piece right now
+ * @param {?Number} props.landingRow - Where a piece would land, null if full
+ * @param {?Object} props.you - Whose piece would be dropped, if anyone's
+ * @param {?Number} props.refusedNonce - Set, and different each time, while this
+ *   column is refusing a drop
+ * @param {Function} props.onActivate - `(col) => void`
+ * @param {Function} props.onHover - `(col | null) => void`
+ * @param {Function} props.onFocus - `(col) => void`
+ * @param {Function} props.onBlur - `() => void`
+ * @param {Function} props.onKeyDown - `(event, col) => void`
+ * @param {Function} props.register - Ref callback for the roving tab stop
+ * @param {Number} props.tabIndex - 0 for the one column that owns the tab stop
+ */
+export const Column = ({
+  active,
+  col,
+  game,
+  interactive,
+  landingRow,
+  onActivate,
+  onBlur,
+  onFocus,
+  onHover,
+  onKeyDown,
+  players,
+  refusedNonce,
+  register,
+  tabIndex,
+  you,
+}) => {
+  const full = landingRow === null;
+  const open = interactive && !full;
+
+  // What the column is, then what pressing it would do. The second half is
+  // absent for a spectator and for the player who is not on the clock, because
+  // for them pressing it does nothing.
+  let label = `Column ${col + 1}, ${describeContents(game, players, col)}`;
+  if (open && you) {
+    label += `. Drop ${you.name} here, landing in row ${landingRow + 1} from the bottom`;
+  }
+
+  const className = [open && "open", interactive && full && "full", active && "active"]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Container
+      aria-disabled={!open}
+      aria-label={label}
+      className={className || undefined}
+      onBlur={onBlur}
+      onClick={() => onActivate(col)}
+      onFocus={() => onFocus(col)}
+      onKeyDown={(event) => onKeyDown(event, col)}
+      onPointerEnter={() => onHover(col)}
+      onPointerLeave={() => onHover(null)}
+      ref={register}
+      tabIndex={tabIndex}
+      type="button"
+    >
+      {/* Remounted on every refusal so the shake replays on the second attempt
+          as well as the first. Keyed on "idle" the rest of the time, so nothing
+          else in the column is ever torn down. */}
+      <Stack
+        className={refusedNonce ? "refused" : undefined}
+        key={refusedNonce ?? "idle"}
+      >
+        {/* Top-down, because that is the order the rows appear on screen —
+            and the engine counts from the bottom, so this is the one place the
+            two conventions have to meet. Row 0 is the LAST cell rendered. */}
+        {range(game.rows - 1, -1, -1).map((row) => {
+          const slot = cellAt(game, col, row);
+          // Every cell the engine names, however many that is. Filling the gap
+          // in ● ● _ ● ● makes a genuine run of five and the engine returns all
+          // of it; slicing to four would leave a piece of the winning line
+          // looking like it lost.
+          const winIndex =
+            game.winningLine?.findIndex(
+              ([wc, wr]) => wc === col && wr === row
+            ) ?? -1;
+
+          return (
+            <Cell
+              dimmed={game.winner !== null && winIndex < 0}
+              /* From the chute, one cell above the top row, down to here. */
+              drop={game.rows - row}
+              key={row}
+              landing={
+                game.lastMove?.col === col && game.lastMove?.row === row
+              }
+              player={slot === null ? null : playerFor(players, slot)}
+              winIndex={winIndex}
+            />
+          );
+        })}
+      </Stack>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/board/Piece.jsx
+++ b/src/app/(pages)/games/connect-404/board/Piece.jsx
@@ -1,0 +1,61 @@
+import styled from "@emotion/styled";
+
+// The disc, and the initial stamped on it.
+//
+// SVG rather than a text node so the letter scales with the board instead of
+// with the root font size: the same markup has to look right in a 4rem cell on
+// a desktop and a 45px one on a phone, and a `font-size` that works at one end
+// is wrong at the other.
+//
+// The element fills its cell and the circle is inset inside it, rather than the
+// element being the circle. That is deliberate: the drop animation moves this
+// element by whole cells, so its height has to *be* one cell.
+const Glyph = styled.svg`
+  display: block;
+  height: 100%;
+  width: 100%;
+
+  text {
+    fill: var(--background);
+    font-family: inherit;
+    font-weight: 700;
+  }
+`;
+
+// Cell units. The board's empty sockets are cut to the same radius, so a piece
+// sits in one exactly.
+export const PIECE_RADIUS = 8.6;
+
+/**
+ * A player's piece.
+ *
+ * The initial is not decoration. Red and blue is a kinder pair than most, but
+ * the site's rule is that colour never carries a fact on its own, and "which of
+ * these is mine" is the only fact this board has.
+ *
+ * @param {Object} props
+ * @param {Object} props.player - A player descriptor from `players.js`
+ */
+export const Piece = ({ player }) => (
+  <Glyph aria-hidden="true" viewBox="0 0 20 20">
+    <circle
+      cx="10"
+      cy="10"
+      fill={player.color}
+      r={PIECE_RADIUS}
+      /* A rim rather than a shadow: it survives the piece being drawn over an
+         empty socket mid-fall, which a drop shadow does not. */
+      stroke="rgba(0, 0, 0, 0.32)"
+      strokeWidth="0.7"
+    />
+    <text
+      dominantBaseline="central"
+      fontSize="9"
+      textAnchor="middle"
+      x="10"
+      y="10.4"
+    >
+      {player.initial}
+    </text>
+  </Glyph>
+);

--- a/src/app/(pages)/games/connect-404/board/animations.js
+++ b/src/app/(pages)/games/connect-404/board/animations.js
@@ -1,0 +1,71 @@
+import { keyframes } from "@emotion/react";
+
+/**
+ * The fall.
+ *
+ * The piece is already in its final cell in the DOM before a single frame of
+ * this runs — every keyframe is an *offset* from where the engine put it, and
+ * the last one is zero. That is the whole trick, and it is the reason the
+ * animation cannot get the landing wrong: there is no frame in which the piece
+ * is anywhere but its own cell, only frames in which it is drawn above it.
+ *
+ * `--drop` is how many cells up the piece starts, which `Cell` derives from the
+ * engine's landing row. Cells are square and stacked with no gap between them,
+ * so one cell is exactly 100% of this element's height and the piece leaves
+ * from the chute it was previewed in.
+ *
+ * The first segment eases in like something falling — a quadratic, near enough —
+ * and the two after it are the bounce it arrives with.
+ */
+export const fall = keyframes`
+  0% {
+    transform: translateY(calc(var(--drop) * -100%));
+    animation-timing-function: cubic-bezier(0.45, 0, 0.75, 0.45);
+  }
+  68% {
+    transform: translateY(0);
+    animation-timing-function: cubic-bezier(0.3, 0, 0.35, 1);
+  }
+  81% {
+    transform: translateY(-9%);
+    animation-timing-function: cubic-bezier(0.6, 0, 0.75, 0.5);
+  }
+  91% {
+    transform: translateY(0);
+    animation-timing-function: ease-out;
+  }
+  96% {
+    transform: translateY(-2.5%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+`;
+
+// Each winning piece swells once, staggered along the line, so the four read as
+// a line being drawn rather than four things lighting up at once. The ring that
+// marks them is permanent CSS underneath — this only draws the eye to it, and a
+// player who arrives after it has finished has lost nothing.
+export const pop = keyframes`
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.22); }
+  100% { transform: scale(1); }
+`;
+
+// A column that will not take another piece. Short, sharp and lateral: it reads
+// as "no" without looking like part of the game.
+export const refuse = keyframes`
+  0%, 100% { transform: translateX(0); }
+  15%      { transform: translateX(-7%); }
+  35%      { transform: translateX(6%); }
+  55%      { transform: translateX(-4%); }
+  75%      { transform: translateX(2.5%); }
+`;
+
+// The next piece arriving in the chute. It replaces one that has just fallen
+// out of it, and without this they overlap for a frame and read as two pieces
+// in one place.
+export const reload = keyframes`
+  from { opacity: 0; transform: scale(0.55); }
+  to   { opacity: 1; transform: scale(1); }
+`;

--- a/src/app/(pages)/games/connect-404/board/index.js
+++ b/src/app/(pages)/games/connect-404/board/index.js
@@ -1,0 +1,2 @@
+export * from "./Board";
+export * from "./Piece";

--- a/src/app/(pages)/games/connect-404/components/Announcer.jsx
+++ b/src/app/(pages)/games/connect-404/components/Announcer.jsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import { playerFor } from "../players";
+import { VisuallyHidden } from "./VisuallyHidden";
+
+const list = (items) =>
+  items.length < 2
+    ? items.join("")
+    : `${items.slice(0, -1).join(", ")} and ${items[items.length - 1]}`;
+
+// Rows are counted from the bottom everywhere a player can hear them, because
+// that is the end of a column a piece actually arrives at. The column labels
+// say "from the bottom" too.
+const cellName = ([col, row]) => `column ${col + 1} row ${row + 1}`;
+
+/**
+ * The running commentary a screen reader hears.
+ *
+ * A player who cannot see the board needs the two facts a sighted player reads
+ * off it instantly: what just landed, and who is up. Where a piece landed is
+ * the whole of the first — a column tells you nothing on its own, because
+ * gravity, not the player, chose the row.
+ *
+ * The winning line is named cell by cell rather than announced as "four in a
+ * row", because "where" is the interesting part and it is the one thing the
+ * highlight on screen conveys that words otherwise would not. It is however
+ * many cells the engine found, which is occasionally five.
+ */
+export const Announcer = ({ game, players }) => {
+  const message = useMemo(() => {
+    const upNext = playerFor(players, game.turn);
+
+    if (!game.lastMove) {
+      return `New game. ${game.cols} columns, ${game.rows} rows. ${upNext.name} to move.`;
+    }
+
+    const { col, row, slot } = game.lastMove;
+    const mover = playerFor(players, slot);
+
+    let sentence = `${mover.name} dropped into column ${col + 1}, landing in row ${
+      row + 1
+    } from the bottom.`;
+
+    if (game.winner !== null) {
+      const line = (game.winningLine ?? []).map(cellName);
+      return `${sentence} ${mover.name} wins with ${line.length} in a row: ${list(
+        line
+      )}.`;
+    }
+
+    if (game.draw) {
+      return `${sentence} The board is full. The game is a draw.`;
+    }
+
+    return `${sentence} ${upNext.name} to move.`;
+  }, [game, players]);
+
+  return (
+    <VisuallyHidden aria-atomic="true" aria-live="polite" role="status">
+      {message}
+    </VisuallyHidden>
+  );
+};

--- a/src/app/(pages)/games/connect-404/components/Button.jsx
+++ b/src/app/(pages)/games/connect-404/components/Button.jsx
@@ -1,0 +1,29 @@
+import styled from "@emotion/styled";
+
+// The game's one button. The mode picker, the join form, the waiting room and
+// the endgame panel all press the same thing.
+export const Button = styled.button`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--selectionBackground);
+  border-radius: 0.5rem;
+  color: var(--foreground);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1rem;
+  padding: 0.5rem 1.25rem;
+  transition: background-color ease-in-out 150ms;
+
+  &:hover {
+    background-color: var(--absentBackground);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    color: var(--absentForeground);
+    cursor: default;
+  }
+`;

--- a/src/app/(pages)/games/connect-404/components/Endgame.jsx
+++ b/src/app/(pages)/games/connect-404/components/Endgame.jsx
@@ -1,0 +1,112 @@
+"use client";
+
+import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+
+const reveal = keyframes`
+  from { opacity: 0; transform: translateY(-0.3rem); }
+  to   { opacity: 1; transform: translateY(0); }
+`;
+
+// Under the board, not over it. The four highlighted pieces are what winning
+// looks like, and a panel that covered them to announce the win would be
+// announcing something the player can no longer see.
+const Panel = styled.div`
+  align-items: center;
+  animation: ${reveal} 300ms ease-out 620ms both;
+  background-color: var(--absentBackground);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.75rem 0.9rem;
+  width: 100%;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;
+
+const Verdict = styled.div`
+  /* Shrinks rather than pushing the button onto a line of its own. It wraps
+     eventually, on a narrow phone, which is the width it should wrap at. */
+  flex: 1 1 10rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.5rem;
+  min-width: 0;
+
+  .slot {
+    color: var(--slot);
+  }
+
+  small {
+    color: var(--absentForeground);
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 400;
+    line-height: 1.05rem;
+  }
+`;
+
+const Again = styled.button`
+  background-color: var(--selectionBackground);
+  border: 1px solid var(--component);
+  border-radius: 0.4rem;
+  color: var(--component);
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 1rem;
+  min-height: 2.75rem;
+  padding: 0.5rem 1.25rem;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * The end of the game, and the rematch.
+ *
+ * Held back until the winning line has finished lighting up — the highlight is
+ * the announcement, and a panel sliding in over the top of it is an
+ * interruption. It is a delay on an entrance animation only: the result is in
+ * the DOM and in the live region from the first frame, so nothing waits on it.
+ *
+ * A draw is reported as a draw. Forty-two pieces and no line is a real outcome
+ * and neither player lost it, so nothing here reaches for a name.
+ *
+ * @param {Object} props
+ * @param {Object} props.game - The finished engine state
+ * @param {Object} props.winner - The winning player descriptor, on a win
+ * @param {Function} [props.onPlayAgain] - Omitted for a spectator, who gets the
+ *   result and no controls.
+ */
+export const Endgame = ({ game, onPlayAgain, winner }) => (
+  <Panel>
+    <Verdict style={{ "--slot": winner?.color }}>
+      {game.draw ? (
+        <>
+          Draw
+          <small>The board is full and there is no line.</small>
+        </>
+      ) : (
+        <>
+          <span className="slot">{winner.name}</span> wins
+          <small>
+            {game.winningLine.length} in a row. {winner.name} opens the next game.
+          </small>
+        </>
+      )}
+    </Verdict>
+
+    {onPlayAgain && (
+      <Again autoFocus onClick={onPlayAgain} type="button">
+        Play again
+      </Again>
+    )}
+  </Panel>
+);

--- a/src/app/(pages)/games/connect-404/components/Panel.jsx
+++ b/src/app/(pages)/games/connect-404/components/Panel.jsx
@@ -1,0 +1,49 @@
+import styled from "@emotion/styled";
+
+// Every screen that is not the board — the mode picker, the join form, the
+// waiting room, a lost connection. They share one shell so moving between them
+// never shifts the layout, and so all of them sit in the same place the board
+// would (same flex growth, same top padding to clear the toolbar).
+
+export const Panel = styled.div`
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-flow: column nowrap;
+  gap: 1.25rem;
+  justify-content: center;
+  padding: 3.5rem 1.5rem 1.5rem;
+  text-align: center;
+  width: 100%;
+`;
+
+export const PanelHeading = styled.h1`
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 2rem;
+  margin: 0;
+
+  @media (min-width: 600px) {
+    font-size: 1.75rem;
+  }
+`;
+
+export const PanelText = styled.p`
+  color: var(--absentForeground);
+  line-height: 1.5rem;
+  margin: 0;
+  max-width: 30rem;
+`;
+
+/** Reserved for something the player did wrong — a bad code, a dead room. */
+export const PanelError = styled(PanelText)`
+  color: var(--invalid);
+`;
+
+export const PanelActions = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.75rem;
+  justify-content: center;
+`;

--- a/src/app/(pages)/games/connect-404/components/TurnBanner.jsx
+++ b/src/app/(pages)/games/connect-404/components/TurnBanner.jsx
@@ -1,0 +1,102 @@
+import styled from "@emotion/styled";
+
+const Container = styled.div`
+  align-items: center;
+  background-color: var(--absentBackground);
+  /* The colour bar. A strip of solid slot colour running the height of the
+     banner is the answer to "which one am I?" from across a table — a small
+     swatch next to a name is not. */
+  border-left: 0.4rem solid var(--slot);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.75rem;
+  min-height: 3.25rem;
+  padding: 0.6rem 0.9rem;
+  width: 100%;
+
+  &.draw {
+    border-left-color: var(--absentForeground);
+  }
+`;
+
+const Chip = styled.span`
+  align-items: center;
+  background-color: var(--slot);
+  border-radius: 50%;
+  color: var(--background);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+  font-weight: 700;
+  height: 2.1rem;
+  justify-content: center;
+  width: 2.1rem;
+`;
+
+const Copy = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.15rem;
+  min-width: 0;
+`;
+
+const Headline = styled.div`
+  color: var(--slot);
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.4rem;
+`;
+
+const Hint = styled.small`
+  color: var(--absentForeground);
+  font-size: 0.8rem;
+  line-height: 1.05rem;
+`;
+
+/**
+ * Whose turn it is, in their colour, at the size the question deserves.
+ *
+ * Rendered after the game as well as during it, because the engine leaves
+ * `turn` with the player who ended it on purpose — the board must never be left
+ * without a valid slot, and therefore never without a colour.
+ *
+ * A draw is the exception and is said plainly. Nobody won; the banner does not
+ * get to imply otherwise by leaving the last mover's name up in their colour.
+ *
+ * @param {Object} props
+ * @param {Object} props.player - The player on the clock (or who ended it)
+ * @param {Object} props.game - The engine state
+ * @param {String} [props.hint] - Overrides the sub-line. An online room puts
+ *   "waiting for Alex…" here.
+ */
+export const TurnBanner = ({ game, hint, player }) => {
+  const headline = game.draw
+    ? "Draw"
+    : game.winner !== null
+      ? `${player.name} wins`
+      : `${player.name} to move`;
+
+  return (
+    <Container
+      className={game.draw ? "draw" : undefined}
+      role="status"
+      style={{ "--slot": player.color }}
+    >
+      <Chip aria-hidden="true">{game.draw ? "—" : player.initial}</Chip>
+      <Copy>
+        <Headline style={game.draw ? { color: "var(--foreground)" } : undefined}>
+          {headline}
+        </Headline>
+        <Hint>
+          {hint ??
+            (game.draw
+              ? "Forty-two pieces, no line."
+              : game.winner !== null
+                ? `${game.winningLine.length} in a row.`
+                : "Four in a row. Nothing found.")}
+        </Hint>
+      </Copy>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/components/VisuallyHidden.js
+++ b/src/app/(pages)/games/connect-404/components/VisuallyHidden.js
@@ -1,0 +1,17 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+// Text for screen readers only. Clipped rather than `display: none`, which
+// would take it out of the accessibility tree along with everything else.
+export const VisuallyHidden = styled.span`
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+`;

--- a/src/app/(pages)/games/connect-404/components/index.js
+++ b/src/app/(pages)/games/connect-404/components/index.js
@@ -1,4 +1,6 @@
 export * from "./Announcer";
+export * from "./Button";
 export * from "./Endgame";
+export * from "./Panel";
 export * from "./TurnBanner";
 export * from "./VisuallyHidden";

--- a/src/app/(pages)/games/connect-404/components/index.js
+++ b/src/app/(pages)/games/connect-404/components/index.js
@@ -1,0 +1,4 @@
+export * from "./Announcer";
+export * from "./Endgame";
+export * from "./TurnBanner";
+export * from "./VisuallyHidden";

--- a/src/app/(pages)/games/connect-404/context/actions.js
+++ b/src/app/(pages)/games/connect-404/context/actions.js
@@ -1,0 +1,31 @@
+/**
+ * The two things that can happen to a Connect 404 game.
+ *
+ * Action creators rather than bare objects because an online room (#114) has to
+ * translate the same intents onto the wire, and it should be translating one
+ * named shape rather than guessing at object literals scattered through the
+ * components.
+ */
+
+export const DROP_PIECE = "DROP PIECE";
+export const NEW_GAME = "NEW GAME";
+
+/**
+ * Drop a piece into a column.
+ *
+ * @param {Number} col - 0-based column
+ * @param {String|Number} slot - Who is dropping it. Passed explicitly rather
+ *   than read off `state.turn` because online the server decides whose move
+ *   this is, and the reducer must be able to refuse a slot that is not up.
+ */
+export const dropPiece = (col, slot) => ({ type: DROP_PIECE, col, slot });
+
+/**
+ * Start over.
+ *
+ * @param {Object} [options]
+ * @param {String|Number} [options.first] - Who opens. Omit and the reducer
+ *   works it out: the winner of the game just finished, or — after a draw — the
+ *   player who did not open it.
+ */
+export const newGame = (options = {}) => ({ type: NEW_GAME, ...options });

--- a/src/app/(pages)/games/connect-404/context/index.jsx
+++ b/src/app/(pages)/games/connect-404/context/index.jsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useMemo, useReducer } from "react";
+
+import reducer from "./reducer";
+// Aliased: `newGame` is also the name of the action creator this module
+// re-exports, and they are different things — one builds a state, one asks for
+// one.
+import { newGame as freshGame } from "./reducer/newGame";
+
+export const createDefaultState = () => freshGame();
+
+export const Context = createContext({
+  state: createDefaultState(),
+  dispatch: () => {},
+  // Null means "this device is the whole game". An online room (#114) fills it
+  // with the per-player view — which seat is yours, the code, the connection —
+  // and that is the only thing below this provider that knows the difference.
+  online: null,
+});
+
+/**
+ * The local hotseat game — two players passing one device.
+ *
+ * Online play swaps this provider for one backed by a room and fills the
+ * identical value shape — `{ state: { game, players, first }, dispatch, online }`
+ * — so everything below keeps working, because nothing below knows where the
+ * state came from. `online` is the only difference, and `Game` reads exactly two
+ * facts off it: which slot this device plays, and whether it may move.
+ */
+export const ContextProvider = ({ children }) => {
+  // Lazily built, but from constants only — the page is prerendered, so the
+  // first client render has to produce exactly the markup the server did.
+  const [state, dispatch] = useReducer(reducer, undefined, createDefaultState);
+
+  const store = useMemo(
+    () => ({ state, dispatch, online: null }),
+    [state, dispatch]
+  );
+
+  return <Context.Provider value={store}>{children}</Context.Provider>;
+};
+
+export * from "./actions";

--- a/src/app/(pages)/games/connect-404/context/reducer/index.js
+++ b/src/app/(pages)/games/connect-404/context/reducer/index.js
@@ -1,0 +1,42 @@
+import { createState, dropPiece as drop, resetState } from "../../_lib";
+import { DROP_PIECE, NEW_GAME } from "../actions";
+import { newGame } from "./newGame";
+
+export { newGame };
+
+/**
+ * The hotseat store.
+ *
+ * Thin on purpose: every rule lives in `_lib`, and this only decides which of
+ * them to ask. An online room (#114) runs the same `_lib` on the server through
+ * `_lib/reducer`, so a rule restated here would be a rule that could disagree
+ * with itself.
+ */
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case DROP_PIECE: {
+      // The engine refuses a full column, a slot that is not up and a finished
+      // game, and hands back the state it was given — the same reference — when
+      // it does. That identity check is the whole rejection path: nothing here
+      // has to know which rules exist, only that one of them said no.
+      const { state: game } = drop(state.game, action.col, action.slot);
+      return game === state.game ? state : { ...state, game };
+    }
+
+    case NEW_GAME:
+      return {
+        ...state,
+        // `resetState` is where "the winner opens the next game" lives — and
+        // where a draw falls back to join order. It is the engine's rule and
+        // the server will apply the same one, so it is not restated here.
+        game: action.first
+          ? createState({ slots: state.game.slots, first: action.first })
+          : resetState(state.game),
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/app/(pages)/games/connect-404/context/reducer/newGame.js
+++ b/src/app/(pages)/games/connect-404/context/reducer/newGame.js
@@ -1,0 +1,14 @@
+import { createState } from "../../_lib";
+import { createPlayers, HOTSEAT_SLOTS } from "../../players";
+
+/**
+ * A fresh state, cast and all.
+ *
+ * @param {Object} [options]
+ * @param {String|Number} [options.first] - Who opens; defaults to the first slot
+ * @returns {Object} `{ game, players }`
+ */
+export const newGame = ({ first } = {}) => ({
+  game: createState({ slots: HOTSEAT_SLOTS, first }),
+  players: createPlayers(HOTSEAT_SLOTS),
+});

--- a/src/app/(pages)/games/connect-404/hooks/index.js
+++ b/src/app/(pages)/games/connect-404/hooks/index.js
@@ -1,0 +1,1 @@
+export * from "./useColumnNavigation";

--- a/src/app/(pages)/games/connect-404/hooks/useColumnNavigation.js
+++ b/src/app/(pages)/games/connect-404/hooks/useColumnNavigation.js
@@ -1,0 +1,73 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { clamp } from "lodash";
+
+/**
+ * Keyboard access to the board.
+ *
+ * Seven columns share one tab stop — a roving tabindex — rather than taking
+ * seven of them, so a player tabbing through the page passes the board in one
+ * press and steers inside it with the arrows. Left and right choose a column;
+ * enter and space drop, which they do by themselves because every column is a
+ * real button.
+ *
+ * Down drops too. It is the direction the piece goes, a keyboard player's hand
+ * is already on the arrows, and the column's own label says so.
+ *
+ * Every column is reachable, full or not: surveying the board is not the same
+ * as moving on it, and a keyboard player has to be able to do the first.
+ *
+ * @param {Number} cols - How many columns there are
+ * @param {Function} onActivate - `(col) => void`, for the down arrow
+ * @returns {Object} The column that owns the tab stop, a ref registrar, and the
+ *   keydown handler to hang off every column
+ */
+export const useColumnNavigation = (cols, onActivate) => {
+  const [activeColumn, setActiveColumn] = useState(0);
+  const elements = useRef(new Map());
+
+  const register = useCallback(
+    (col) => (element) => {
+      if (element) elements.current.set(col, element);
+      else elements.current.delete(col);
+    },
+    []
+  );
+
+  const focusColumn = useCallback((col) => {
+    setActiveColumn(col);
+    elements.current.get(col)?.focus();
+  }, []);
+
+  const onKeyDown = useCallback(
+    (event, col) => {
+      // Clamped rather than wrapped. Seven columns is few enough that a player
+      // holding an arrow down is aiming at the end of the row, and wrapping
+      // would carry them past it to the other side of the board.
+      const target = {
+        ArrowLeft: () => clamp(col - 1, 0, cols - 1),
+        ArrowRight: () => clamp(col + 1, 0, cols - 1),
+        Home: () => 0,
+        End: () => cols - 1,
+      }[event.key];
+
+      if (target) {
+        // Swallowed even at the rim, so the page never scrolls out from under
+        // a player steering the board.
+        event.preventDefault();
+        focusColumn(target());
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        onActivate(col);
+      }
+    },
+    [cols, focusColumn, onActivate]
+  );
+
+  return useMemo(
+    () => ({ activeColumn, focusColumn, onKeyDown, register }),
+    [activeColumn, focusColumn, onKeyDown, register]
+  );
+};

--- a/src/app/(pages)/games/connect-404/multiplayer.js
+++ b/src/app/(pages)/games/connect-404/multiplayer.js
@@ -1,0 +1,100 @@
+import { defineGame } from "@/lib/realtime/games";
+
+import { createState, reducer as engineReducer, resetState } from "./_lib";
+import { NEW_GAME } from "./context/actions";
+
+// The networked half of Connect 404: the rules the engine already plays,
+// wrapped in the shape src/lib/realtime asks for.
+//
+// Named `multiplayer.js` rather than the `game.js` the core's README suggests
+// because `Game.jsx` sits beside it, and two modules whose names differ only in
+// case resolve to each other on Windows and macOS — webpack calls that a real
+// casing collision and refuses to build.
+//
+// This module is pure on purpose. It is imported by the API routes (where it is
+// the authority) *and* by the browser (where `useRoom` runs it to preview a
+// drop), so it must contain no JSX, no `window`, no clock and no randomness —
+// the two copies have to agree exactly or the optimistic board drifts. The two
+// modules it imports are pure for the same reason.
+//
+// Every rule below is *called*, never restated: `_lib`'s reducer is the same
+// function the hotseat store dispatches to, and its `resetState` is the same
+// "new game". A second implementation of "four in a row" would drift silently,
+// and it is the rule players would notice last.
+
+export const C404_GAME_ID = "connect-404";
+
+// Both seats exist from the moment the room does, so the board can too. An
+// ARRAY, in seat order, because it becomes the engine's turn order and MySQL
+// does not preserve the key order of anything else stored in a room.
+export const SEATS = Object.freeze([0, 1]);
+
+/** The seat that opens the very first game of a room. */
+export const FIRST_SEAT = SEATS[0];
+
+// The engine reports a refusal as `{ code, message }` so a caller can branch on
+// the code; the core wants the one sentence it will put in a 422 and a player
+// will read. Flattening that is the whole reason this adapter exists — hand the
+// object through and the browser renders "[object Object]".
+const refusal = (error) =>
+  (typeof error === "string" ? error : error?.message) ||
+  "That move is not allowed.";
+
+export const connect404 = defineGame({
+  id: C404_GAME_ID,
+  maxPlayers: 2,
+  minPlayers: 2,
+  // Nothing to pick, so nothing to negotiate: red is whoever created the room
+  // and blue is whoever joined it, which makes a colour a seat. An empty palette
+  // leaves `player.color` null rather than storing a second answer that could
+  // disagree with `players.js` — that module is the only one that says what a
+  // seat looks like.
+  colors: [],
+  // Two seats, and gravity on a seven-wide board only divides two ways.
+  allowLateJoin: false,
+
+  // Deliberately ignores the roster it is handed: `_lib/createState` THROWS on
+  // anything but exactly two slots, and a room is created with one player in
+  // it. The seats are fixed and known, so the board is built from those and the
+  // second one is filled the moment somebody joins.
+  createState: () => createState({ slots: [...SEATS], first: FIRST_SEAT }),
+
+  /**
+   * The server's authority and the client's preview, in one function.
+   *
+   * `player` is resolved from the request's token by the core, so "it is not
+   * your turn" is checked against a seat the client had no say in choosing —
+   * request bodies never name a slot. Everything but the rematch is handed
+   * straight to the engine.
+   */
+  reducer: (state, action, player) => {
+    // The one action the engine has no opinion about: a new game is a room-level
+    // event, not a move. Either player may ask for it, so the next game never
+    // waits on the one who just lost to press something — and `resetState` is
+    // where "the winner opens the next game" lives, falling back to seat order
+    // after a draw. Same function the hotseat store calls.
+    if (action?.type === NEW_GAME) {
+      if (!state.slots.includes(player.slot)) {
+        return { error: "You are not seated at this board." };
+      }
+      if (!state.finished) {
+        return { error: "Finish this game before starting the next one." };
+      }
+      return { state: resetState(state) };
+    }
+
+    const result = engineReducer(state, action, player);
+    if (result.error) return { error: refusal(result.error) };
+    return { state: result.state };
+  },
+
+  // Derived, never stored. "lobby" is what puts the waiting screen up until the
+  // second player arrives; "over" is what stops a stranger with the code
+  // wandering into a finished room and taking a seat.
+  status: (state, players) => {
+    if (players.length < SEATS.length) return "lobby";
+    return state.finished ? "over" : "playing";
+  },
+});
+
+export default connect404;

--- a/src/app/(pages)/games/connect-404/online/OnlineBar.jsx
+++ b/src/app/(pages)/games/connect-404/online/OnlineBar.jsx
@@ -1,0 +1,157 @@
+import { useContext } from "react";
+import styled from "@emotion/styled";
+
+import { AWAY, LEFT, absenceSentence } from "@/lib/realtime/absence";
+
+import { Button } from "../components";
+import { Context } from "../context";
+import { playerFor } from "../players";
+
+// The per-player strip above the board: which room this is, which colour is
+// yours, who you are playing, and anything the connection wants to admit to.
+// Everything it needs is already on the context, so it is rendered as <Game>'s
+// banner from inside the provider and takes no props but the way out.
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+  line-height: 1.25rem;
+  text-align: center;
+`;
+
+const Row = styled.div`
+  align-items: center;
+  column-gap: 1rem;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  row-gap: 0.25rem;
+`;
+
+const Item = styled.span`
+  align-items: center;
+  color: var(--absentForeground);
+  display: inline-flex;
+  gap: 0.4rem;
+`;
+
+const Code = styled.span`
+  color: var(--parenthesis);
+  font-weight: 700;
+  letter-spacing: 0.15em;
+`;
+
+// The disc the board will drop for you, at the size of a word — and the colour
+// is named beside it, because "the red one" is not a description a monochrome
+// screen or a protanope can act on.
+const Chip = styled.span`
+  background-color: ${({ color }) => color};
+  border-radius: 50%;
+  display: inline-block;
+  height: 0.9rem;
+  width: 0.9rem;
+`;
+
+const Leave = styled.button`
+  background: none;
+  border: none;
+  color: var(--vscode);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  padding: 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--var);
+    outline-offset: 2px;
+  }
+`;
+
+// Reconnecting is ordinary and a refused move is not, but both are the same
+// kind of interruption to a player: something is wrong and it is not the board.
+const Warning = styled.div`
+  color: var(--invalid);
+`;
+
+// The opponent, not the connection — so deliberately not a Warning. Nothing is
+// broken here; somebody is either briefly away or has gone home, and the two
+// are told apart by tone as much as by wording.
+const Absence = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.5rem;
+
+  /* A blink. Said once, quietly, in the same voice as the rest of the strip. */
+  &.away {
+    color: var(--absentForeground);
+  }
+
+  /* Final. Worth a colour, because the board below it will never move again. */
+  &.left {
+    color: var(--string);
+  }
+`;
+
+const Ending = styled(Button)`
+  font-size: 0.9rem;
+  padding: 0.35rem 0.9rem;
+`;
+
+export const OnlineBar = ({ onLeave }) => {
+  const { online, state } = useContext(Context);
+  const { absence, code, connected, notice, opponent, spectating, youSlot } =
+    online;
+
+  // The same descriptor the board draws your discs from, so the strip and the
+  // board cannot end up disagreeing about what colour you are.
+  const you = spectating ? null : playerFor(state.players, youSlot);
+
+  return (
+    <Container>
+      <Row>
+        <Item>
+          Room <Code>{code}</Code>
+        </Item>
+        {you ? (
+          <>
+            <Item>
+              You are <Chip aria-hidden="true" color={you.color} />
+              {you.colorName}
+            </Item>
+            <Item>vs {opponent}</Item>
+          </>
+        ) : (
+          <Item>Watching — this room is full</Item>
+        )}
+        <Item>
+          <Leave onClick={onLeave} type="button">
+            Leave
+          </Leave>
+        </Item>
+      </Row>
+      {absence !== null && (
+        // `role="status"` for both: neither is an emergency, and an assertive
+        // alert would cut across whatever a screen reader was in the middle of
+        // saying about the board.
+        <Absence className={absence} role="status">
+          <span>{absenceSentence(opponent, absence)}</span>
+          {absence === AWAY && (
+            <span>The board picks up where it left off.</span>
+          )}
+          {absence === LEFT && (
+            <Ending onClick={onLeave} type="button">
+              Back to the menu
+            </Ending>
+          )}
+        </Absence>
+      )}
+      {!connected && <Warning role="status">Reconnecting…</Warning>}
+      {notice !== null && <Warning role="alert">{notice}</Warning>}
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/online/OnlineGame.jsx
+++ b/src/app/(pages)/games/connect-404/online/OnlineGame.jsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+import { absenceOf } from "@/lib/realtime/absence";
+import { useRoom } from "@/lib/realtime/useRoom";
+
+import Game from "../Game";
+import {
+  Button,
+  Panel,
+  PanelActions,
+  PanelHeading,
+  PanelText,
+} from "../components";
+import { DROP_PIECE, NEW_GAME } from "../context/actions";
+import { Context } from "../context";
+import { C404_GAME_ID, SEATS } from "../multiplayer";
+import { createPlayers } from "../players";
+import { OnlineBar } from "./OnlineBar";
+import { RoomCode } from "./RoomCode";
+
+/**
+ * Online Connect 404: the same board, driven by a realtime room.
+ *
+ * This component's whole job is to fill the game's context from `useRoom`
+ * instead of from a `useReducer`. The board, the turn banner and the endgame
+ * panel do not know the difference, which is the point — there is one board in
+ * this codebase, not two.
+ */
+export const OnlineGame = ({ code, onLeave }) => {
+  const {
+    connected,
+    error,
+    leave,
+    me,
+    players: seats,
+    room,
+    send,
+    spectating,
+    state: game,
+    status,
+  } = useRoom({ code, game: C404_GAME_ID });
+
+  const [notice, setNotice] = useState(null);
+
+  // The seat this browser holds, resolved by the server from its token. Null for
+  // a spectator, which is what closes the board to them.
+  const youSlot = me?.slot ?? null;
+  // Null for a spectator on purpose: they are not playing anybody, and picking
+  // one of the two seats arbitrarily would put "so-and-so left the game" on a
+  // screen that has no stake in it.
+  const opponent =
+    youSlot === null
+      ? null
+      : (seats.find((seat) => seat.slot !== youSlot) ?? null);
+
+  // Walking away is not the same as navigating away. Giving the seat up first
+  // is what turns "the board just stopped" into a sentence on the other
+  // player's screen; without it they wait out the presence timeout for news
+  // that was available the instant this button was pressed.
+  const quit = useCallback(async () => {
+    await leave();
+    onLeave();
+  }, [leave, onLeave]);
+
+  // A drop goes over the wire without the slot the hotseat action carries: the
+  // server resolves who moved from the request's token, and a slot in a body is
+  // a slot somebody can lie about. Everything else about the move — a full
+  // column, whose turn it is, whether four are in a row — is the engine's, and
+  // it is the same engine at both ends.
+  const drop = useCallback(
+    async (col) => {
+      const action = { type: DROP_PIECE, col };
+      let result = await send(action, { optimistic: true });
+
+      // 409 means the opponent's drop landed between the render we tapped and
+      // the request we sent. `send` has already applied the board we missed, so
+      // the same tap is worth exactly one more try against it — and only one,
+      // because a second failure means the column really is contested.
+      if (!result.ok && result.error === "stale-revision") {
+        result = await send(action, { optimistic: true });
+      }
+
+      setNotice(result.ok ? null : (result.message ?? null));
+    },
+    [send],
+  );
+
+  const rematch = useCallback(async () => {
+    const result = await send({ type: NEW_GAME });
+    // Both players may reach for it at once. Losing that race is not something
+    // to put on screen — the new board is already on its way.
+    const raced =
+      result.error === "stale-revision" || result.error === "rejected";
+    setNotice(result.ok || raced ? null : (result.message ?? null));
+  }, [send]);
+
+  // The hotseat store's action creators, answered over the wire. Same actions
+  // in, same board out; only the authority moved.
+  const dispatch = useCallback(
+    (action) => {
+      switch (action?.type) {
+        case DROP_PIECE:
+          drop(action.col);
+          break;
+        case NEW_GAME:
+          rematch();
+          break;
+        default:
+          break;
+      }
+    },
+    [drop, rematch],
+  );
+
+  // The board's cast, built by the same function the hotseat game uses so the
+  // colours, initials and fallbacks are identical in both modes. Names are
+  // positional against SEATS, never against the room's roster — a player who has
+  // left keeps their seat and their place in this list, and a room in the lobby
+  // has a hole in it.
+  const cast = useMemo(
+    () =>
+      createPlayers([...SEATS], {
+        names: SEATS.map(
+          (slot) => seats.find((seat) => seat.slot === slot)?.name,
+        ),
+      }),
+    [seats],
+  );
+
+  const store = useMemo(
+    () => ({
+      state: { game, players: cast },
+      dispatch,
+      online: {
+        // Left or dropped, so the bar can explain a board that has stopped
+        // moving. Mid-game the seat is never deleted — it has to stay for the
+        // turn order to make sense — so this is the only way the other player
+        // finds out.
+        absence: absenceOf(opponent),
+        code,
+        connected,
+        notice,
+        opponent: opponent?.name ?? "your opponent",
+        spectating,
+        // `Game` reads exactly this off `online`, and closes the board when it
+        // is not the seat on the clock.
+        youSlot,
+      },
+    }),
+    [
+      cast,
+      code,
+      connected,
+      dispatch,
+      game,
+      notice,
+      opponent,
+      spectating,
+      youSlot,
+    ],
+  );
+
+  // 410 is terminal and reads differently depending on whether we ever got in:
+  // a room we were playing in has died, a room we never reached never existed.
+  if (error?.code === "gone") {
+    return (
+      <Panel>
+        <PanelHeading>Connection lost</PanelHeading>
+        <PanelText>
+          {room
+            ? "This room is gone — a game closes after an hour without a move. Create a new game to play again."
+            : `Nothing is waiting on ${code}. Check the code, or create a new game to play again.`}
+        </PanelText>
+        <PanelActions>
+          <Button onClick={onLeave} type="button">
+            Back to the menu
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  // No snapshot yet. An `error` here is the handshake failing rather than the
+  // room being dead, so the hook is still retrying behind this screen.
+  if (!room) {
+    return (
+      <Panel>
+        <PanelHeading>
+          {error ? "Can’t reach the game" : "Connecting…"}
+        </PanelHeading>
+        {error && <PanelText>{error.message}</PanelText>}
+        <PanelActions>
+          <Button onClick={onLeave} type="button">
+            Back to the menu
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  if (status === "lobby") {
+    return (
+      <Panel>
+        <PanelHeading>Waiting for a second player</PanelHeading>
+        <PanelText>
+          Read this code out, or send the link. The game starts the moment
+          somebody joins.
+        </PanelText>
+        <RoomCode code={code} />
+        <PanelActions>
+          <Button onClick={quit} type="button">
+            Cancel
+          </Button>
+        </PanelActions>
+      </Panel>
+    );
+  }
+
+  return (
+    <Context.Provider value={store}>
+      <Game banner={<OnlineBar onLeave={quit} />} />
+    </Context.Provider>
+  );
+};
+
+export default OnlineGame;

--- a/src/app/(pages)/games/connect-404/online/RoomCode.jsx
+++ b/src/app/(pages)/games/connect-404/online/RoomCode.jsx
@@ -1,0 +1,57 @@
+import { useCallback, useState } from "react";
+import styled from "@emotion/styled";
+
+import { Button } from "../components";
+
+// The code is the whole invitation, so it is the biggest thing on the screen
+// and it is spelled out for a screen reader one letter at a time — "K7F2" read
+// as a word helps nobody.
+
+const Container = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 1rem;
+`;
+
+const Code = styled.div`
+  color: var(--parenthesis);
+  font-size: clamp(3.5rem, 20vw, 6rem);
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  line-height: 1.1;
+  /* letter-spacing pads the right of the final glyph too; pull the block back
+     by the same amount so the code still reads as centred. */
+  text-indent: 0.3em;
+`;
+
+export const RoomCode = ({ code }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    const { origin, pathname } = window.location;
+    try {
+      await navigator.clipboard.writeText(`${origin}${pathname}?room=${code}`);
+      setCopied(true);
+    } catch {
+      // Clipboard access can be refused outright (an insecure origin, a
+      // permission prompt dismissed). The code is on screen either way, which
+      // is the part that actually matters.
+      setCopied(false);
+    }
+  }, [code]);
+
+  return (
+    <Container>
+      <Code aria-label={`Room code ${[...code].join(" ")}`} role="img">
+        {code}
+      </Code>
+      <Button onClick={copy} type="button">
+        <span>
+          <i className="fa-regular fa-copy" />
+        </span>{" "}
+        {copied ? "Link copied!" : "Copy invite link"}
+      </Button>
+    </Container>
+  );
+};

--- a/src/app/(pages)/games/connect-404/online/index.js
+++ b/src/app/(pages)/games/connect-404/online/index.js
@@ -1,0 +1,3 @@
+export * from "./OnlineBar";
+export * from "./OnlineGame";
+export * from "./RoomCode";

--- a/src/app/(pages)/games/connect-404/page.js
+++ b/src/app/(pages)/games/connect-404/page.js
@@ -1,0 +1,25 @@
+import { Connect404 } from "./Connect404";
+
+// "Connect 404" is the name; "connect four" is what people search for. Both
+// stay in the description and keywords so the page is findable either way.
+export const metadata = {
+  title: "Connect 404 — Connect Four | Christopher Salinas Jr.",
+  description:
+    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device, seven columns, six rows, and a piece that falls where gravity puts it.",
+  keywords: [
+    "connect four",
+    "connect 4",
+    "connect four online",
+    "connect four 2 player",
+    "four in a row",
+    "Connect 404",
+  ],
+  openGraph: {
+    title: "Connect 404 — Connect Four",
+    description:
+      "Four in a row. Nothing found. Two players, one device, seven columns and gravity.",
+    type: "website",
+  },
+};
+
+export default Connect404;

--- a/src/app/(pages)/games/connect-404/page.js
+++ b/src/app/(pages)/games/connect-404/page.js
@@ -5,7 +5,7 @@ import { Connect404 } from "./Connect404";
 export const metadata = {
   title: "Connect 404 — Connect Four | Christopher Salinas Jr.",
   description:
-    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device, seven columns, six rows, and a piece that falls where gravity puts it.",
+    "Four in a row. Nothing found. Play Connect Four in your browser — two players on one device or online with a code, seven columns, six rows, and a piece that falls where gravity puts it.",
   keywords: [
     "connect four",
     "connect 4",
@@ -17,7 +17,7 @@ export const metadata = {
   openGraph: {
     title: "Connect 404 — Connect Four",
     description:
-      "Four in a row. Nothing found. Two players, one device, seven columns and gravity.",
+      "Four in a row. Nothing found. Two players, one device or two, seven columns and gravity.",
     type: "website",
   },
 };

--- a/src/app/(pages)/games/connect-404/players.js
+++ b/src/app/(pages)/games/connect-404/players.js
@@ -1,0 +1,95 @@
+/**
+ * Connect 404 — who is who, and what colour they are.
+ *
+ * The engine only ever deals in opaque "slots". Everything a human needs to
+ * tell one slot from another — a name, an initial, a colour — lives here, in
+ * ONE shape that both the hotseat game and an online room (#114) build:
+ *
+ *   { slot, name, initial, color, colorName, token }
+ *
+ * `color` is a CSS custom property reference, so it resolves anywhere the theme
+ * does and stays in step with it.
+ *
+ * Colour is never the only signal. Every piece is stamped with its player's
+ * initial as well as filled with their colour — red and blue is a kinder pair
+ * than most, but "the red one" is still not a description a monochrome screen
+ * or a protanope can act on.
+ */
+
+// Red first, blue second, straight out of the reference implementation
+// (`csalinas-dev/connect4`, where P1 is a red disc and P2 a blue one) and off
+// the site palette rather than out of a crayon box.
+export const PLAYER_PALETTE = Object.freeze([
+  { choice: "red", colorName: "Red", color: "var(--invalid)", token: "--invalid" },
+  {
+    choice: "blue",
+    colorName: "Blue",
+    color: "var(--component)",
+    token: "--component",
+  },
+]);
+
+/** The colours a room offers, in the order the picker shows them. */
+export const COLOR_CHOICES = Object.freeze(PLAYER_PALETTE.map((p) => p.choice));
+
+/**
+ * Wire colour name → palette entry.
+ * @param {String} choice - "red" | "blue"
+ * @returns {?Object} The palette entry, or null for anything unrecognised
+ */
+export const paletteFor = (choice) =>
+  PLAYER_PALETTE.find((entry) => entry.choice === choice) ?? null;
+
+// The slot ids a local hotseat game uses. Strings rather than numbers, matching
+// Edge Case: a slot ends up as an object key often enough that it may as well
+// already be one.
+export const HOTSEAT_SLOTS = Object.freeze(["p1", "p2"]);
+
+/**
+ * Player descriptors for a list of slots, in join order.
+ *
+ * Names default to the colour ("Red", "Blue") because on a shared device the
+ * colour IS the identity — nobody has typed a name in. An online room hands in
+ * real names instead; the initial follows whatever name it is given.
+ *
+ * @param {(String|Number)[]} slots - Slots in join order, at most two
+ * @param {Object} [options]
+ * @param {String[]} [options.names] - Display names, positional, optional
+ * @param {String[]} [options.colors] - Chosen colours ("red", "blue"), positional
+ * @returns {Object[]} One `{ slot, name, initial, color, colorName, token }` per slot
+ */
+export const createPlayers = (slots, { names = [], colors = [] } = {}) =>
+  slots.slice(0, PLAYER_PALETTE.length).map((slot, index) => {
+    const { color, colorName, token } =
+      paletteFor(colors[index]) ?? PLAYER_PALETTE[index];
+    const name = names[index] || colorName;
+
+    return {
+      slot,
+      name,
+      // Trimmed first, so " chris" still initials as "C" rather than a space.
+      initial: name.trim().charAt(0).toUpperCase() || colorName.charAt(0),
+      color,
+      colorName,
+      token,
+    };
+  });
+
+/**
+ * Slot → player descriptor, for the many components that hold a slot and need a
+ * colour. Falls back to a neutral descriptor rather than throwing, so a
+ * mismatched slot can never blank the board mid-game.
+ *
+ * @param {Object[]} players - Player descriptors
+ * @param {String|Number} slot - The slot to look up
+ * @returns {Object} A player descriptor
+ */
+export const playerFor = (players, slot) =>
+  players.find((player) => player.slot === slot) ?? {
+    slot,
+    name: "Player",
+    initial: "?",
+    color: "var(--foreground)",
+    colorName: "grey",
+    token: "--foreground",
+  };

--- a/src/app/(pages)/games/page.jsx
+++ b/src/app/(pages)/games/page.jsx
@@ -18,7 +18,8 @@ const Container = styled.div`
   grid-template-areas:
     "wordle hashtag"
     "tictacoverflow tictacoverflow"
-    "edgecase edgecase";
+    "edgecase edgecase"
+    "connect404 connect404";
   grid-template-columns: 1fr 1fr;
   grid-template-rows: auto;
 
@@ -42,15 +43,26 @@ const Container = styled.div`
     grid-area: edgecase;
   }
 
+  .connect404 {
+    aspect-ratio: 2 / 1;
+    grid-area: connect404;
+  }
+
   @media (min-width: 896px) {
     gap: 3rem;
   }
 
+  /* One row, and from here on every card is the same tall portrait. The old
+     layout gave Edge Case a double-width column, which only looked square
+     because the row was as tall as the 1:2 cards beside it; a fifth game makes
+     five equal columns both simpler and narrower than that column ever was. */
   @media (min-width: 1296px) {
-    grid-template-areas: "wordle hashtag tictacoverflow edgecase";
-    grid-template-columns: 1fr 1fr 1fr 2fr;
+    grid-template-areas: "wordle hashtag tictacoverflow edgecase connect404";
+    grid-template-columns: repeat(5, 1fr);
 
-    .tictacoverflow {
+    .tictacoverflow,
+    .edgecase,
+    .connect404 {
       aspect-ratio: 1 / 2;
     }
   }
@@ -272,6 +284,88 @@ const EdgeCaseArtwork = () => {
   );
 };
 
+// Seven columns, six rows, and the columns are written bottom-up — the same way
+// round they are in the engine, where `columns[c][0]` is the disc resting on the
+// floor. Red has just taken the bottom row; a ghost hangs over column six to say
+// that a turn here is a column, not a square.
+const C404_CELL = 42;
+const C404_ORIGIN = { x: 3, y: 48 };
+const C404_COLUMNS = [
+  ["blue"],
+  ["red", "blue"],
+  ["red", "blue", "red"],
+  ["red", "blue"],
+  ["red"],
+  [],
+  [],
+];
+const C404_WIN = [1, 2, 3, 4];
+const C404_FILL = { red: "#f44747", blue: "#4fc1ff" };
+
+const c404x = (col) => C404_ORIGIN.x + C404_CELL * (col + 0.5);
+// Height 0 is the floor, so it is the *last* of the six rows on screen.
+const c404y = (height) => C404_ORIGIN.y + C404_CELL * (5 - height + 0.5);
+
+const Connect404Artwork = () => {
+  const discs = C404_COLUMNS.flatMap((column, col) =>
+    column.map((color, height) => ({
+      color,
+      cx: c404x(col),
+      cy: c404y(height),
+      key: `${col}-${height}`,
+    })),
+  );
+
+  return (
+    <svg viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+      {/* The plate is a solid sheet with forty-two holes punched through it, so
+          the discs below show through exactly as they do in the real thing. */}
+      <mask id="connect404-holes">
+        <rect fill="#ffffff" height="252" rx="10" width="294" x="3" y="48" />
+        {C404_COLUMNS.map((_, col) =>
+          [0, 1, 2, 3, 4, 5].map((height) => (
+            <circle
+              cx={c404x(col)}
+              cy={c404y(height)}
+              fill="#000000"
+              key={`${col}-${height}`}
+              r="16"
+            />
+          )),
+        )}
+      </mask>
+
+      {/* Nobody's turn yet — the disc waiting above the column it would fall
+          down. Drawn first so the plate crops nothing of it. */}
+      <circle cx={c404x(5)} cy="24" fill={C404_FILL.red} opacity="0.35" r="15" />
+
+      {discs.map(({ color, cx, cy, key }) => (
+        <circle cx={cx} cy={cy} fill={C404_FILL[color]} key={key} r="15" />
+      ))}
+
+      <rect
+        fill="rgba(173, 214, 255, 0.15)"
+        height="252"
+        mask="url(#connect404-holes)"
+        rx="10"
+        width="294"
+        x="3"
+        y="48"
+      />
+
+      <line
+        stroke="#ffd700"
+        strokeLinecap="round"
+        strokeWidth="7"
+        x1={c404x(C404_WIN[0])}
+        x2={c404x(C404_WIN[C404_WIN.length - 1])}
+        y1={c404y(0)}
+        y2={c404y(0)}
+      />
+    </svg>
+  );
+};
+
 export default function Page() {
   return (
     <Section>
@@ -328,6 +422,18 @@ export default function Page() {
               <Module>Play</Module>
               <br />
               Edge Case
+            </div>
+          </CardTitle>
+        </Card>
+        <Card className="connect404" href="/games/connect-404">
+          <CardArtwork aria-hidden="true" className="artwork">
+            <Connect404Artwork />
+          </CardArtwork>
+          <CardTitle>
+            <div>
+              <Module>Play</Module>
+              <br />
+              Connect 404
             </div>
           </CardTitle>
         </Card>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -134,6 +134,7 @@ export const Nav = () => {
           <NavLink href="/games/hashtag">Hashtag</NavLink>
           <NavLink href="/games/tic-tac-overflow">Tic-Tac-Overflow</NavLink>
           <NavLink href="/games/edge-case">Edge Case</NavLink>
+          <NavLink href="/games/connect-404">Connect 404</NavLink>
           {/* Mini Motorways is unlinked for now. The page is still served at
               /games/mini-motorways — this only hides the way in. */}
         </Menu>

--- a/src/lib/realtime/registry.js
+++ b/src/lib/realtime/registry.js
@@ -1,3 +1,4 @@
+import { connect404 } from "@/app/(pages)/games/connect-404/multiplayer";
 import { edgeCase } from "@/app/(pages)/games/edge-case/multiplayer";
 import { ticTacOverflow } from "@/app/(pages)/games/tic-tac-overflow/multiplayer";
 
@@ -18,6 +19,7 @@ import { unknownGame } from "./errors";
 const GAMES = [
   ticTacOverflow, // "tto"       -> #88
   edgeCase, //       "edge-case" -> #89
+  connect404, //     "connect-404" -> #111
 ];
 
 for (const def of GAMES) registerGame(def);


### PR DESCRIPTION
Closes #111, and its sub-issues #112, #113, #114.

**Connect 404** at `/games/connect-404` — Connect Four, offline and online, red and blue, seven columns, animated.

## On the reference repo

`csalinas-dev/connect4` is a 69-line Node console app, and its README still lists *"Determine if/when someone wins"* as an unfinished TODO — so win detection was the substantial new work here rather than something to port. What carried over is the shape: red is player one, blue is player two, seven columns, and columns modelled as stacks you push onto, which is how gravity actually behaves.

## What ships

- **Engine** (#112) — pure rules, the single authority for both server and client. Four in a row in any direction, draws reported as draws, illegal moves refused with a reason.
- **Board** (#113) — hover preview that follows the cursor and the arrow keys, a drop animation, a highlighted winning line, full keyboard play, `prefers-reduced-motion`, responsive to 320px.
- **Online** (#114) — mode picker, 4-char codes, `?room=` deep links, winner-opens-the-next-game rematch, presence and departure notices. Third game on the realtime core that shipped with #88/#89, so this was wiring rather than invention.
- Games index card and nav entry.

## Built concurrently against a contract pinned up front

The board and the online mode both need the engine's state shape, so rather than serialising the work I fixed the contract before starting and had all three built at once, with file ownership partitioned so they could not collide. **Row 0 is the bottom of a column** was called out in every brief, because the board renders top-down and reads those in reverse — the easiest thing to invert, and exactly the class of ambiguity that produced three different bugs across three agents on a previous epic.

## Verification

**The engine, re-derived independently.** I wrote my own win scanner, separate from the engine's, and ran it against 800 random full games: it agreed on every winner, no floating pieces ever appeared, piece counts were exact, and `landingRow` predicted every landing.

```
winningLine is the FULL run of five  [[0,0],[1,0],[2,0],[3,0],[4,0]]
horizontal / vertical / diag up / diag down   ✓
800 games — wins=798 draws=2, independent scanner agreed on all
```

**The animation cannot decide where a piece lands.** This was the thing most likely to be subtly wrong. Pieces are rendered into the cell the engine chose *before* a frame runs, and every keyframe is an offset ending at zero — there is no frame in which a piece is anywhere but its own cell, only frames in which it is drawn above it. Confirmed by playing: column 1's announced landing rows came out 1, 2, 3, 4 as red stacked, and the screen reader named the winning cells exactly.

**`winningLine` is never sliced to four.** Filling the gap in `● ● _ ● ●` makes a genuine run of five and the engine returns the whole run; the UI highlights all of it and reads `.length` to say "5 in a row". This was caught mid-build and relayed to the board agent before it could hard-code a 4.

**Hotseat makes zero network requests.** Verified from `performance.getEntriesByType("resource")` across a full game to a win — the only `/api/` call is NextAuth's pre-existing session check.

**The server is the authority.** Bypassing the UI, a drop out of turn is refused `422 "It is not your turn."` even with `slot: 0` forged in both the body and the action, and the message arrives as a string rather than an object. A seatless token gets 403.

All five game routes 200; games index and nav both link correctly.

## Worth knowing

- **The games index reflowed.** A fifth card does not fit the old four-column row, so past 1296px it is now five equal portraits — which changes the Edge Case tile from double-width to portrait. Checked, and it reads consistently; its artwork arguably renders more correctly this way.
- **`createState` hard-codes seats `[0, 1]`** rather than deriving them from the roster: the engine throws on anything but exactly two slots, and a room is created with one player in it. Safe, but it is the definition asserting seat identity rather than reading it.
- **The spectator path is wired but was not opened with a third identity.** It is core behaviour shared with the other two games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
