### PR TITLE
feat(wordle): opt-in Wordleverse leaderboard

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,20 +15,23 @@ datasource db {
 
 // NextAuth Models
 model User {
-  id             String          @id @default(cuid())
-  name           String?
-  email          String?         @unique
-  emailVerified  DateTime?
-  password       String? // Added for credentials authentication
-  image          String?
-  accounts       Account[]
-  sessions       Session[]
-  wordleGames    WordleGame[]
-  streak         Int             @default(0)
-  maxStreak      Int             @default(0)
-  lastPlayedDate String? // Format: yyyy-mm-dd
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  id                String       @id @default(cuid())
+  name              String?
+  email             String?      @unique
+  emailVerified     DateTime?
+  password          String? // Added for credentials authentication
+  image             String?
+  accounts          Account[]
+  sessions          Session[]
+  wordleGames       WordleGame[]
+  streak            Int          @default(0)
+  maxStreak         Int          @default(0)
+  lastPlayedDate    String? // Format: yyyy-mm-dd
+  // Wordleverse leaderboard is opt-in: OAuth hands us real names the user never
+  // meant to publish, so nobody is listed until they say so.
+  showOnLeaderboard Boolean      @default(false)
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
 }
 
 model Account {

--- a/src/app/(pages)/games/wordleverse/(game)/Header.jsx
+++ b/src/app/(pages)/games/wordleverse/(game)/Header.jsx
@@ -85,6 +85,15 @@ const NavLinks = styled.div`
     gap: 0.5rem;
     font-size: 0.8rem;
   }
+
+  /* Three labelled links overflow the toolbar on a phone, so drop to icons
+     only. Hidden with CSS, never by conditionally rendering: the Font Awesome
+     kit swaps the <i> for an <svg> in the DOM and unmounting one throws. */
+  @media (max-width: 600px) {
+    .label {
+      display: none;
+    }
+  }
 `;
 
 const Toggle = styled.span`
@@ -130,11 +139,17 @@ const Header = ({ date }) => {
         </Box>
         <div>
           <NavLinks>
+            <Link href="/games/wordleverse/leaderboard">
+              <i className="fa-solid fa-ranking-star" />{" "}
+              <span className="label">Leaderboard</span>
+            </Link>
             <Link href="/games/wordleverse/history">
-              <i className="fa-solid fa-clock-rotate-left" /> History
+              <i className="fa-solid fa-clock-rotate-left" />{" "}
+              <span className="label">History</span>
             </Link>
             <Link href="/games/wordleverse/instructions">
-              <i className="fa-regular fa-circle-question" /> How to Play
+              <i className="fa-regular fa-circle-question" />{" "}
+              <span className="label">How to Play</span>
             </Link>
           </NavLinks>
         </div>

--- a/src/app/(pages)/games/wordleverse/CLAUDE.md
+++ b/src/app/(pages)/games/wordleverse/CLAUDE.md
@@ -105,6 +105,17 @@ Prisma read, with no client fetch.
   exists and fail the build.
 - Narrow screens hide columns with a CSS media query (`.hide-narrow`), never by
   dropping them from the data — the payload must not depend on the viewport.
+- **The opt-in switch is optimistic, so every failure path is a privacy
+  question.** A position that sticks without being saved tells a listed player
+  they have been removed while their name is still on both boards. So
+  `setLeaderboardOptIn` keeps `getCurrentUser()` *inside* its `try` — it does a
+  Prisma read and must come back as a returned `{ error }` rather than a
+  rejected promise, because React silently swallows the rejection of an `async`
+  event handler — and `OptInToggle` reverts the switch and shows a message both
+  on a returned error and in a `catch`. Only a boolean the server confirmed
+  survives. For the same reason `getLeaderboard()`'s catch reports `optedIn:
+  null`, not `false`: the setting was never read, and "you are not listed" would
+  be a guess. `null` disables the switch and suppresses the notice.
 
 ## Key Invariants
 

--- a/src/app/(pages)/games/wordleverse/CLAUDE.md
+++ b/src/app/(pages)/games/wordleverse/CLAUDE.md
@@ -6,6 +6,7 @@ A daily Wordle clone. Each day has a single deterministic word (seed-based from 
 
 - Game URL: `/games/wordleverse` (today) or `/games/wordleverse?date=YYYY-MM-DD` (past)
 - History URL: `/games/wordleverse/history`
+- Leaderboard URL: `/games/wordleverse/leaderboard`
 - Valid date range: 2024-01-01 through today
 
 ## Directory Structure
@@ -26,13 +27,20 @@ wordleverse/
 │   │   └── localStorage/# Browser storage fallback
 │   ├── Game.jsx         # Root client component (no SSR — uses dynamic import)
 │   └── page.js          # Server component with date validation
-└── history/             # History + stats feature
-    ├── _actions/        # getHistory server action
-    ├── _components/     # Calendar, Stats, SignInPrompt
-    └── _lib/storage/
-        ├── index.js     # useHistory hook (picks DB or localStorage)
-        ├── database.js  # getHistoryFromDB server action
-        └── localStorage.js # getHistoryFromLocalStorage
+├── history/             # History + stats feature
+│   ├── _actions/        # getHistory server action
+│   ├── _components/     # Calendar, Stats, SignInPrompt
+│   └── _lib/storage/
+│       ├── index.js     # useHistory hook (picks DB or localStorage)
+│       ├── database.js  # getHistoryFromDB server action
+│       └── localStorage.js # getHistoryFromLocalStorage
+└── leaderboard/         # Public leaderboard (opt-in)
+    ├── _actions/        # setLeaderboardOptIn
+    ├── _components/     # Layout, LeaderboardTabs, TodayBoard, AllTimeBoard, Board, OptInToggle
+    ├── _lib/
+    │   ├── rank.js      # Pure ranking rules — every leaderboard rule lives here
+    │   └── leaderboard.js # getLeaderboard() — the Prisma reads
+    └── page.js          # Server component, force-dynamic
 ```
 
 ## Dual Storage Architecture
@@ -66,6 +74,37 @@ The word list is `src/data/words.json` — it is **both** the answer pool and th
 - `saveGame(data)` — **upsert** (handles both in-flight saves and migration)
 - `updateStreak(userId, isWin)` — called after a game completes on today's date; streak counts consecutive days *played* (not just wins)
 - All actions call `getCurrentUser()` to get the authenticated user by email
+
+## Leaderboard
+
+`/games/wordleverse/leaderboard` is a server component with two boards — **Today**
+(everyone who finished today's puzzle) and **All Time** — rendered from one
+Prisma read, with no client fetch.
+
+- **Appearance is opt-in and off by default**: `User.showOnLeaderboard Boolean
+  @default(false)`. OAuth hands us real names the player never meant to publish,
+  so nobody is listed until they flip the switch. Both queries filter on the
+  flag, so an un-opted-in user cannot leak in through either board. The only way
+  to change it is `_actions/setLeaderboardOptIn.js`, which always writes the
+  *caller's own* row (`getCurrentUser()`), never an id from the argument.
+- **Every ranking rule lives in `_lib/rank.js`** and nothing may re-derive one in
+  a component. That includes the guess count (`guesses` is null on legacy rows,
+  so it falls back to `row + 1` and clamps to 1..6 — the `IQUIT` concede path
+  sets `row: 6`), the sort order, and competition ranks (equal keys share a rank,
+  the next rank skips). The module is pure — no Prisma, no `next/*`, no React.
+- `rank.js` is also the privacy boundary: it resolves `isYou` against the
+  viewer's id and then drops the identifiers, so **no row that reaches a
+  component carries a user id or an email**, and nothing rendered contains the
+  day's word or any guess string.
+- "Today" is `dateFormat(new Date(), "yyyy-mm-dd")`, server-local — identical to
+  how `(game)/_actions/saveGame.js` writes `WordleGame.date`. Any other
+  definition silently empties the board around midnight.
+- `page.js` **must** keep `export const dynamic = "force-dynamic"`. The Docker
+  image runs `next build` before the deploy runs `prisma db push`, so a
+  statically prerendered page would query `showOnLeaderboard` before the column
+  exists and fail the build.
+- Narrow screens hide columns with a CSS media query (`.hide-narrow`), never by
+  dropping them from the data — the payload must not depend on the viewport.
 
 ## Key Invariants
 

--- a/src/app/(pages)/games/wordleverse/leaderboard/_actions/setLeaderboardOptIn.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_actions/setLeaderboardOptIn.js
@@ -15,14 +15,18 @@ import prisma from "@/lib/prisma";
  * @returns {Object} The stored value, or an error
  */
 export const setLeaderboardOptIn = async (optIn) => {
-  const user = await getCurrentUser();
-  if (!user) {
-    return { error: "Unauthorized", status: 401 };
-  }
-
   const showOnLeaderboard = Boolean(optIn);
 
   try {
+    // Inside the try on purpose: getCurrentUser() does a Prisma read, so it can
+    // throw. Everything this action can fail at has to come back as a returned
+    // error, because the caller is an optimistic switch and a rejected promise
+    // would leave it showing the opposite of what is stored.
+    const user = await getCurrentUser();
+    if (!user) {
+      return { error: "Unauthorized", status: 401 };
+    }
+
     await prisma.user.update({
       where: { id: user.id },
       data: { showOnLeaderboard },

--- a/src/app/(pages)/games/wordleverse/leaderboard/_actions/setLeaderboardOptIn.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_actions/setLeaderboardOptIn.js
@@ -1,0 +1,38 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getCurrentUser } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+/**
+ * Set whether the signed-in user appears on the Wordleverse leaderboard.
+ *
+ * The row updated is always the caller's own — the id comes from the session,
+ * never from the argument — and the argument is coerced, because everything a
+ * server action is handed is attacker-controlled.
+ * @param {Boolean} optIn - Whether to list the caller
+ * @returns {Object} The stored value, or an error
+ */
+export const setLeaderboardOptIn = async (optIn) => {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { error: "Unauthorized", status: 401 };
+  }
+
+  const showOnLeaderboard = Boolean(optIn);
+
+  try {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { showOnLeaderboard },
+    });
+
+    revalidatePath("/games/wordleverse/leaderboard");
+
+    return { optIn: showOnLeaderboard };
+  } catch (error) {
+    console.error("Error setting leaderboard opt-in:", error);
+    return { error: "Failed to update leaderboard setting", status: 500 };
+  }
+};

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/AllTimeBoard.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/AllTimeBoard.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Empty, Player, Table } from "./Board";
+
+/**
+ * Every opted-in player who has finished at least one puzzle, most wins first.
+ *
+ * Purely presentational — every row arrives ranked and formatted from
+ * `_lib/rank.js`, and nothing here re-derives a rule. Average guesses and max
+ * streak are hidden by CSS on a narrow screen rather than dropped from the
+ * data, so nothing about the payload depends on the viewport.
+ * @param {Object} props - Component props
+ * @param {Array} props.rows - AllTimeRow[] from rankAllTime
+ * @returns {JSX.Element} AllTimeBoard component
+ */
+const AllTimeBoard = ({ rows }) => {
+  if (rows.length === 0) {
+    return <Empty>No games on the board yet.</Empty>;
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th className="rank">#</th>
+          <th>Player</th>
+          <th className="numeric">Wins</th>
+          <th className="numeric">Win %</th>
+          <th className="numeric hide-narrow">Avg</th>
+          <th className="numeric">Streak</th>
+          <th className="numeric hide-narrow">Max</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={index} className={row.isYou ? "you" : undefined}>
+            <td className="rank">{row.rank}</td>
+            <td>
+              <Player
+                name={row.name}
+                initials={row.initials}
+                isYou={row.isYou}
+              />
+            </td>
+            <td className="numeric">{row.wins}</td>
+            <td className="numeric">{row.winPct}%</td>
+            <td className="numeric hide-narrow">
+              {row.avgGuesses === null ? "—" : row.avgGuesses}
+            </td>
+            <td className="numeric">{row.streak}</td>
+            <td className="numeric hide-narrow">{row.maxStreak}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default AllTimeBoard;

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/Board.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/Board.jsx
@@ -1,0 +1,127 @@
+"use client";
+
+import styled from "@emotion/styled";
+import { Avatar } from "@mui/material";
+
+/**
+ * Table chrome shared by both boards, so the two tables cannot drift apart.
+ *
+ * Cell classes:
+ * - `rank`        right-aligned, muted rank column
+ * - `numeric`     right-aligned figure that must not wrap
+ * - `hide-narrow` hidden under 700px — the column is still in the data, it is
+ *                 only not drawn, so nothing downstream has to know about it
+ */
+export const Table = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+
+  th,
+  td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  th {
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: normal;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  thead tr,
+  tbody tr {
+    border-bottom: 1px solid var(--absentBackground);
+  }
+
+  tbody tr.you {
+    background-color: var(--selectionBackground);
+  }
+
+  .rank,
+  .numeric {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .rank {
+    color: var(--muted);
+    width: 3.5rem;
+  }
+
+  @media (max-width: 700px) {
+    .hide-narrow {
+      display: none;
+    }
+
+    th,
+    td {
+      padding: 0.5rem 0.35rem;
+    }
+  }
+`;
+
+const PlayerCell = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 0.5rem;
+  min-width: 0;
+`;
+
+// A definite max-width is what lets the ellipsis engage — a long OAuth display
+// name must not be allowed to widen the table.
+const Name = styled.span`
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: 700px) {
+    max-width: 7rem;
+  }
+`;
+
+const You = styled.span`
+  color: var(--muted);
+  flex: 0 0 auto;
+  font-size: 0.8rem;
+`;
+
+/**
+ * A player's avatar and name.
+ *
+ * Initials rather than an OAuth avatar image: `next.config.mjs` only allows
+ * `media.graphassets.com` as a remote image host, and the leaderboard makes no
+ * other third-party request.
+ * @param {Object} props - Component props
+ * @param {String} props.name - Display name
+ * @param {String} props.initials - Up to two initials
+ * @param {Boolean} props.isYou - Whether this row is the viewer's
+ * @returns {JSX.Element} Player component
+ */
+export const Player = ({ name, initials, isYou }) => (
+  <PlayerCell>
+    <Avatar
+      sx={{
+        backgroundColor: "var(--absentBackground)",
+        color: "var(--foreground)",
+        fontSize: "0.75rem",
+        height: 28,
+        width: 28,
+      }}
+    >
+      {initials}
+    </Avatar>
+    <Name title={name}>{name}</Name>
+    {isYou && <You>(you)</You>}
+  </PlayerCell>
+);
+
+export const Empty = styled.p`
+  color: var(--muted);
+  margin: 2rem 0;
+  text-align: center;
+`;

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/Layout.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/Layout.js
@@ -35,7 +35,7 @@ const NavLink = styled(Link)`
 `;
 
 /**
- * Layout component for the history page
+ * Layout component for the leaderboard page
  * @param {Object} props - Component props
  * @param {React.ReactNode} props.children - Child components
  * @returns {JSX.Element} Layout component
@@ -48,16 +48,16 @@ const Layout = ({ children }) => {
         flexDirection: "column",
         paddingTop: 4,
         paddingBottom: 10,
-        gap: 10,
+        gap: 4,
         "& > *": { width: "100%" },
       }}
     >
       <Header>
         <Links>
           <NavLink href="/games/wordleverse">← Back to Game</NavLink>
-          <NavLink href="/games/wordleverse/leaderboard">Leaderboard</NavLink>
+          <NavLink href="/games/wordleverse/history">History</NavLink>
         </Links>
-        <Title>Wordleverse History</Title>
+        <Title>Wordleverse Leaderboard</Title>
       </Header>
       {children}
     </Container>

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/LeaderboardTabs.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/LeaderboardTabs.jsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import styled from "@emotion/styled";
+import { Tab, Tabs } from "@mui/material";
+
+import { FormattedDate } from "@/components";
+
+import AllTimeBoard from "./AllTimeBoard";
+import TodayBoard from "./TodayBoard";
+
+const TODAY = "today";
+const ALL_TIME = "allTime";
+
+const Caption = styled.p`
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 1rem 0 0;
+  text-align: center;
+`;
+
+const Notice = styled.p`
+  background-color: var(--absentBackground);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+`;
+
+/**
+ * The two boards behind a pair of tabs.
+ *
+ * Both datasets arrive as props from the server component, so switching tabs
+ * renders instantly and makes no request.
+ * @param {Object} props - Component props
+ * @param {String} props.date - Today's date, yyyy-mm-dd
+ * @param {Boolean} props.signedIn - Whether anyone is signed in
+ * @param {Boolean} props.optedIn - Whether the viewer is listed
+ * @param {Array} props.today - TodayRow[]
+ * @param {Array} props.allTime - AllTimeRow[]
+ * @returns {JSX.Element} LeaderboardTabs component
+ */
+const LeaderboardTabs = ({ date, signedIn, optedIn, today, allTime }) => {
+  const [tab, setTab] = useState(TODAY);
+
+  return (
+    <div>
+      {signedIn && !optedIn && (
+        <Notice>
+          You are not listed. Turn on &ldquo;Show me on the leaderboard&rdquo; to
+          appear here.
+        </Notice>
+      )}
+      <Tabs
+        value={tab}
+        onChange={(event, value) => setTab(value)}
+        textColor="inherit"
+        variant="fullWidth"
+        sx={{ "& .MuiTabs-indicator": { backgroundColor: "var(--comment)" } }}
+      >
+        <Tab value={TODAY} label="Today" />
+        <Tab value={ALL_TIME} label="All Time" />
+      </Tabs>
+      {tab === TODAY ? (
+        <>
+          <Caption>
+            {/* Parse at local midnight — a bare yyyy-mm-dd is read as UTC and
+                would render as the previous day west of Greenwich. */}
+            <FormattedDate date={new Date(`${date}T00:00:00`)} />
+          </Caption>
+          <TodayBoard rows={today} />
+        </>
+      ) : (
+        <AllTimeBoard rows={allTime} />
+      )}
+    </div>
+  );
+};
+
+export default LeaderboardTabs;

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/LeaderboardTabs.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/LeaderboardTabs.jsx
@@ -37,7 +37,7 @@ const Notice = styled.p`
  * @param {Object} props - Component props
  * @param {String} props.date - Today's date, yyyy-mm-dd
  * @param {Boolean} props.signedIn - Whether anyone is signed in
- * @param {Boolean} props.optedIn - Whether the viewer is listed
+ * @param {Boolean} props.optedIn - Whether the viewer is listed, null if unknown
  * @param {Array} props.today - TodayRow[]
  * @param {Array} props.allTime - AllTimeRow[]
  * @returns {JSX.Element} LeaderboardTabs component
@@ -47,7 +47,9 @@ const LeaderboardTabs = ({ date, signedIn, optedIn, today, allTime }) => {
 
   return (
     <div>
-      {signedIn && !optedIn && (
+      {/* Only when the setting was actually read as false — `optedIn` is null
+          when the query failed, and "you are not listed" would be a guess. */}
+      {signedIn && optedIn === false && (
         <Notice>
           You are not listed. Turn on &ldquo;Show me on the leaderboard&rdquo; to
           appear here.

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
@@ -20,34 +20,67 @@ const ErrorMessage = styled.span`
   font-size: 0.9rem;
 `;
 
+const FAILED =
+  "Failed to update leaderboard setting. You are still listed as before.";
+const UNKNOWN =
+  "Could not read your leaderboard setting. Reload to try again.";
+
 /**
  * The opt-in switch. Listing is off by default, so this is the only way onto
  * the board — and off it.
+ *
+ * The switch is optimistic, which makes every failure path a privacy question:
+ * a position that sticks without being saved tells a listed player they have
+ * been removed while their name is still on both boards. So the only state that
+ * survives an attempt is one the server confirmed, and anything else puts the
+ * switch back and says why.
  * @param {Object} props - Component props
- * @param {Boolean} props.optedIn - The stored setting
+ * @param {Boolean} props.optedIn - The stored setting, or null when unreadable
  * @returns {JSX.Element} OptInToggle component
  */
 const OptInToggle = ({ optedIn }) => {
   const router = useRouter();
-  const [checked, setChecked] = useState(optedIn);
-  const [error, setError] = useState(null);
+  // Null means the page could not read the setting. Never guess at it: show the
+  // switch off, refuse to act, and say so.
+  const unknown = optedIn !== true && optedIn !== false;
+  const [checked, setChecked] = useState(optedIn === true);
+  const [error, setError] = useState(unknown ? UNKNOWN : null);
+  const [saving, setSaving] = useState(false);
   const [pending, startTransition] = useTransition();
 
   const onChange = async (event) => {
     const next = event.target.checked;
 
-    // Move the switch immediately, put it back if the server disagrees.
+    // Move the switch immediately, put it back unless the server confirms it.
     setChecked(next);
     setError(null);
+    setSaving(true);
 
-    const result = await setLeaderboardOptIn(next);
-    if (result?.error) {
+    try {
+      const result = await setLeaderboardOptIn(next);
+
+      // Anything that is not an explicit stored boolean is a failure — a
+      // returned { error }, or a shape this component does not recognise.
+      if (typeof result?.optIn !== "boolean") {
+        setChecked(!next);
+        setError(result?.error ?? FAILED);
+        return;
+      }
+
+      // Re-sync from what was stored rather than trusting the optimistic value.
+      setChecked(result.optIn);
+      startTransition(() => router.refresh());
+    } catch (error) {
+      // Reachable: a server action can throw before it reaches its own
+      // try/catch, and React swallows the rejection of an async event handler.
+      // Unhandled, that is the failure that publishes somebody who believes
+      // they opted out.
+      console.error("Error setting leaderboard opt-in:", error);
       setChecked(!next);
-      setError(result.error);
-      return;
+      setError(FAILED);
+    } finally {
+      setSaving(false);
     }
-
-    startTransition(() => router.refresh());
   };
 
   return (
@@ -56,7 +89,9 @@ const OptInToggle = ({ optedIn }) => {
         control={
           <Switch
             checked={checked}
-            disabled={pending}
+            // `saving` is set before the await, so a second click during the
+            // round trip finds the switch already disabled.
+            disabled={pending || saving || unknown}
             onChange={onChange}
             sx={{
               "& .Mui-checked": { color: "var(--comment)" },
@@ -68,7 +103,7 @@ const OptInToggle = ({ optedIn }) => {
         }
         label="Show me on the leaderboard"
       />
-      {error && <ErrorMessage>{error}</ErrorMessage>}
+      {error && <ErrorMessage role="alert">{error}</ErrorMessage>}
     </ToggleContainer>
   );
 };

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import styled from "@emotion/styled";
+import { FormControlLabel, Switch } from "@mui/material";
+import { useRouter } from "next/navigation";
+
+import { setLeaderboardOptIn } from "../_actions/setLeaderboardOptIn";
+
+const ToggleContainer = styled.div`
+  align-items: center;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 0.5rem;
+  justify-content: center;
+`;
+
+const ErrorMessage = styled.span`
+  color: var(--invalid);
+  font-size: 0.9rem;
+`;
+
+/**
+ * The opt-in switch. Listing is off by default, so this is the only way onto
+ * the board — and off it.
+ * @param {Object} props - Component props
+ * @param {Boolean} props.optedIn - The stored setting
+ * @returns {JSX.Element} OptInToggle component
+ */
+const OptInToggle = ({ optedIn }) => {
+  const router = useRouter();
+  const [checked, setChecked] = useState(optedIn);
+  const [error, setError] = useState(null);
+  const [pending, startTransition] = useTransition();
+
+  const onChange = async (event) => {
+    const next = event.target.checked;
+
+    // Move the switch immediately, put it back if the server disagrees.
+    setChecked(next);
+    setError(null);
+
+    const result = await setLeaderboardOptIn(next);
+    if (result?.error) {
+      setChecked(!next);
+      setError(result.error);
+      return;
+    }
+
+    startTransition(() => router.refresh());
+  };
+
+  return (
+    <ToggleContainer>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={checked}
+            disabled={pending}
+            onChange={onChange}
+            sx={{
+              "& .Mui-checked": { color: "var(--comment)" },
+              "& .Mui-checked + .MuiSwitch-track": {
+                backgroundColor: "var(--comment)",
+              },
+            }}
+          />
+        }
+        label="Show me on the leaderboard"
+      />
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+    </ToggleContainer>
+  );
+};
+
+export default OptInToggle;

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/TodayBoard.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/TodayBoard.jsx
@@ -1,0 +1,70 @@
+"use client";
+
+import styled from "@emotion/styled";
+
+import { Empty, Player, Table } from "./Board";
+
+const Result = styled.span`
+  color: ${(props) => (props.win ? "var(--comment)" : "var(--muted)")};
+  font-weight: bold;
+`;
+
+const ExpertBadge = styled.span`
+  background-color: var(--absentBackground);
+  border-radius: 3px;
+  color: var(--module);
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.3rem;
+  vertical-align: middle;
+`;
+
+/**
+ * Today's finishers, best result first.
+ *
+ * Purely presentational — every row arrives ranked and formatted from
+ * `_lib/rank.js`, and nothing here re-derives a rule.
+ * @param {Object} props - Component props
+ * @param {Array} props.rows - TodayRow[] from rankToday
+ * @returns {JSX.Element} TodayBoard component
+ */
+const TodayBoard = ({ rows }) => {
+  if (rows.length === 0) {
+    return <Empty>No one has finished today&apos;s puzzle yet.</Empty>;
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th className="rank">#</th>
+          <th>Player</th>
+          <th className="numeric">Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={index} className={row.isYou ? "you" : undefined}>
+            <td className="rank">{row.rank}</td>
+            <td>
+              <Player
+                name={row.name}
+                initials={row.initials}
+                isYou={row.isYou}
+              />
+            </td>
+            <td className="numeric">
+              <Result win={row.win}>
+                {row.win ? `${row.guessCount}/6` : "X/6"}
+              </Result>
+              {row.expert && <ExpertBadge>EXPERT</ExpertBadge>}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+};
+
+export default TodayBoard;

--- a/src/app/(pages)/games/wordleverse/leaderboard/_lib/leaderboard.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_lib/leaderboard.js
@@ -1,0 +1,86 @@
+import dateFormat from "dateformat";
+
+import { getCurrentUser } from "@/lib/auth";
+import prisma from "@/lib/prisma";
+
+import { rankAllTime, rankToday } from "./rank";
+
+/**
+ * Read both boards for the leaderboard page.
+ *
+ * Only users who have opted in (`User.showOnLeaderboard`) are queried at all,
+ * so a player who has never flipped the switch cannot appear even by accident.
+ * The aggregation runs in JS rather than SQL because the guess count lives in a
+ * JSON column and this is a personal site with a small user table.
+ *
+ * "Today" is `dateFormat(new Date(), "yyyy-mm-dd")` — server-local, exactly how
+ * `(game)/_actions/saveGame.js` writes `WordleGame.date`. Any other definition
+ * silently empties the board around midnight.
+ * @returns {Object} { date, signedIn, optedIn, today, allTime }
+ */
+export const getLeaderboard = async () => {
+  const date = dateFormat(new Date(), "yyyy-mm-dd");
+  let user = null;
+
+  try {
+    user = await getCurrentUser();
+
+    const [games, users, viewer] = await Promise.all([
+      prisma.wordleGame.findMany({
+        where: {
+          date,
+          completed: true,
+          win: { not: null },
+          user: { is: { showOnLeaderboard: true } },
+        },
+        select: {
+          win: true,
+          guesses: true,
+          row: true,
+          expert: true,
+          updatedAt: true,
+          userId: true,
+          user: { select: { name: true } },
+        },
+      }),
+      prisma.user.findMany({
+        where: { showOnLeaderboard: true },
+        select: {
+          id: true,
+          name: true,
+          streak: true,
+          maxStreak: true,
+          wordleGames: {
+            where: { completed: true },
+            select: { win: true, guesses: true, row: true },
+          },
+        },
+      }),
+      // getCurrentUser does not select the flag, so ask for it separately.
+      user
+        ? prisma.user.findUnique({
+            where: { id: user.id },
+            select: { showOnLeaderboard: true },
+          })
+        : null,
+    ]);
+
+    return {
+      date,
+      signedIn: Boolean(user),
+      optedIn: viewer?.showOnLeaderboard === true,
+      today: rankToday(games, user?.id ?? null),
+      allTime: rankAllTime(users, user?.id ?? null),
+    };
+  } catch (error) {
+    // A database hiccup should cost the boards, not the whole page.
+    console.error("Error getting leaderboard:", error);
+    return {
+      date,
+      signedIn: Boolean(user),
+      optedIn: false,
+      today: [],
+      allTime: [],
+    };
+  }
+};

--- a/src/app/(pages)/games/wordleverse/leaderboard/_lib/leaderboard.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_lib/leaderboard.js
@@ -16,7 +16,8 @@ import { rankAllTime, rankToday } from "./rank";
  * "Today" is `dateFormat(new Date(), "yyyy-mm-dd")` — server-local, exactly how
  * `(game)/_actions/saveGame.js` writes `WordleGame.date`. Any other definition
  * silently empties the board around midnight.
- * @returns {Object} { date, signedIn, optedIn, today, allTime }
+ * @returns {Object} { date, signedIn, optedIn, today, allTime } — `optedIn` is
+ *                   true, false, or null when the setting could not be read
  */
 export const getLeaderboard = async () => {
   const date = dateFormat(new Date(), "yyyy-mm-dd");
@@ -73,12 +74,15 @@ export const getLeaderboard = async () => {
       allTime: rankAllTime(users, user?.id ?? null),
     };
   } catch (error) {
-    // A database hiccup should cost the boards, not the whole page.
+    // A database hiccup should cost the boards, not the whole page. `optedIn`
+    // is null rather than false because the setting was not read: reporting
+    // false would tell a listed player they are not on a board that is only
+    // empty because the query failed.
     console.error("Error getting leaderboard:", error);
     return {
       date,
       signedIn: Boolean(user),
-      optedIn: false,
+      optedIn: null,
       today: [],
       allTime: [],
     };

--- a/src/app/(pages)/games/wordleverse/leaderboard/_lib/rank.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_lib/rank.js
@@ -30,6 +30,15 @@ export const guessCountOf = (game) => {
 };
 
 /**
+ * The first *code point* of a word. Indexing with [0] would take a UTF-16 code
+ * unit, which halves a surrogate pair — an emoji or astral-plane name would
+ * render as tofu in the avatar.
+ * @param {String} word - A whitespace-free word
+ * @returns {String} Its first character, whole
+ */
+const firstCharOf = (word) => Array.from(word)[0] ?? "";
+
+/**
  * Up to two initials, from the first and last words of a name.
  * @param {String} name - The player's name, possibly null
  * @returns {String} Initials, or "?" when there is no name
@@ -38,8 +47,8 @@ export const initialsOf = (name) => {
   const words = (name ?? "").trim().split(/\s+/).filter(Boolean);
   if (words.length === 0) return "?";
 
-  const first = words[0][0];
-  const last = words.length > 1 ? words[words.length - 1][0] : "";
+  const first = firstCharOf(words[0]);
+  const last = words.length > 1 ? firstCharOf(words[words.length - 1]) : "";
   return `${first}${last}`.toUpperCase();
 };
 

--- a/src/app/(pages)/games/wordleverse/leaderboard/_lib/rank.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_lib/rank.js
@@ -1,0 +1,165 @@
+/**
+ * Every leaderboard rule lives here.
+ *
+ * The module is pure — no Prisma, no `next/*`, no React — so the ordering, the
+ * guess counting and the name formatting can be reasoned about (and reused)
+ * without a database. Nothing downstream may re-derive one of these rules: the
+ * components render the rows they are handed.
+ *
+ * It is also the privacy boundary. `isYou` is resolved here against the
+ * viewer's id and the identifiers are then dropped, so no row that leaves this
+ * module carries a user id or an email.
+ */
+
+const MAX_GUESSES = 6;
+
+/**
+ * How many guesses a finished game used, always in 1..6.
+ *
+ * `guesses` is `Json?` and is null on rows written before it was persisted, so
+ * fall back to `row + 1` — on a win `row` is the winning row index and is never
+ * incremented (see `(game)/_lib/compare.js`). The concede path (`IQUIT`) sets
+ * `row: 6`, which is why the result is clamped.
+ * @param {Object} game - A completed WordleGame row
+ * @returns {Number} Guesses used, 1..6
+ */
+export const guessCountOf = (game) => {
+  const n = Array.isArray(game?.guesses) ? game.guesses.length : 0;
+  const count = n > 0 ? n : (game?.row ?? 0) + 1;
+  return Math.min(Math.max(count, 1), MAX_GUESSES);
+};
+
+/**
+ * Up to two initials, from the first and last words of a name.
+ * @param {String} name - The player's name, possibly null
+ * @returns {String} Initials, or "?" when there is no name
+ */
+export const initialsOf = (name) => {
+  const words = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+
+  const first = words[0][0];
+  const last = words.length > 1 ? words[words.length - 1][0] : "";
+  return `${first}${last}`.toUpperCase();
+};
+
+/**
+ * The name to show for a player who never set one.
+ * @param {String} name - The player's name, possibly null
+ * @returns {String} A non-empty display name
+ */
+export const displayName = (name) => {
+  const trimmed = (name ?? "").trim();
+  return trimmed.length > 0 ? trimmed : "Anonymous";
+};
+
+const timeOf = (value) => {
+  const time = new Date(value ?? 0).getTime();
+  return Number.isNaN(time) ? 0 : time;
+};
+
+/**
+ * Assign competition ranks — equal keys share a rank and the next rank skips.
+ * @param {Array} rows - Rows already in display order
+ * @param {Function} keyOf - Produces the comparison key for a row
+ * @returns {Array} The same rows with a `rank` property
+ */
+const withRanks = (rows, keyOf) => {
+  let rank = 0;
+  let previousKey = null;
+
+  return rows.map((row, index) => {
+    const key = keyOf(row);
+    if (key !== previousKey) {
+      rank = index + 1;
+      previousKey = key;
+    }
+    return { ...row, rank };
+  });
+};
+
+/**
+ * Rank everyone who finished today's puzzle.
+ *
+ * Wins come before losses, then fewer guesses, then whoever finished first.
+ * Finishing first only breaks the *display* order — the rank itself is keyed on
+ * (win, guessCount), so two players who solved it in three share a rank.
+ * @param {Array} games - Today's completed games, each with `user.name`
+ * @param {String} viewerId - The signed-in user's id, or null
+ * @returns {Array} TodayRow[] — { rank, name, initials, win, guessCount, expert, isYou }
+ */
+export const rankToday = (games, viewerId) => {
+  const rows = (games ?? [])
+    .map((game) => ({
+      name: displayName(game.user?.name),
+      initials: initialsOf(game.user?.name),
+      win: game.win === true,
+      guessCount: guessCountOf(game),
+      expert: game.expert === true,
+      isYou: Boolean(viewerId) && game.userId === viewerId,
+      finishedAt: timeOf(game.updatedAt),
+    }))
+    .sort((a, b) => {
+      if (a.win !== b.win) return a.win ? -1 : 1;
+      if (a.guessCount !== b.guessCount) return a.guessCount - b.guessCount;
+      return a.finishedAt - b.finishedAt;
+    })
+    // `finishedAt` only ever broke the display order; it never leaves here.
+    .map(({ finishedAt, ...row }) => row);
+
+  return withRanks(rows, (row) => `${row.win}|${row.guessCount}`);
+};
+
+/**
+ * Rank opted-in players over every game they have completed.
+ *
+ * Users with no completed games are dropped — an empty row says nothing and
+ * would sit at the bottom of the board forever. `avgGuesses` is null for a
+ * player who has never won (there is no average to take) and sorts last.
+ * @param {Array} users - Opted-in users with their completed `wordleGames`
+ * @param {String} viewerId - The signed-in user's id, or null
+ * @returns {Array} AllTimeRow[] — { rank, name, initials, played, wins, winPct,
+ *                  avgGuesses, streak, maxStreak, isYou }
+ */
+export const rankAllTime = (users, viewerId) => {
+  const rows = (users ?? [])
+    .map((user) => {
+      const games = user.wordleGames ?? [];
+      const won = games.filter((game) => game.win === true);
+      const played = games.length;
+      const wins = won.length;
+      const totalGuesses = won.reduce(
+        (total, game) => total + guessCountOf(game),
+        0
+      );
+
+      return {
+        name: displayName(user.name),
+        initials: initialsOf(user.name),
+        played,
+        wins,
+        winPct: played > 0 ? Math.round((wins / played) * 100) : 0,
+        avgGuesses:
+          wins > 0 ? Math.round((totalGuesses / wins) * 100) / 100 : null,
+        streak: user.streak ?? 0,
+        maxStreak: user.maxStreak ?? 0,
+        isYou: Boolean(viewerId) && user.id === viewerId,
+      };
+    })
+    .filter((row) => row.played > 0)
+    .sort((a, b) => {
+      if (a.wins !== b.wins) return b.wins - a.wins;
+      if (a.avgGuesses !== b.avgGuesses) {
+        if (a.avgGuesses === null) return 1;
+        if (b.avgGuesses === null) return -1;
+        return a.avgGuesses - b.avgGuesses;
+      }
+      if (a.maxStreak !== b.maxStreak) return b.maxStreak - a.maxStreak;
+      return a.name.localeCompare(b.name);
+    });
+
+  return withRanks(
+    rows,
+    (row) => `${row.wins}|${row.avgGuesses}|${row.maxStreak}`
+  );
+};

--- a/src/app/(pages)/games/wordleverse/leaderboard/page.js
+++ b/src/app/(pages)/games/wordleverse/leaderboard/page.js
@@ -1,0 +1,30 @@
+import SignInPrompt from "@wordleverse-history/_components/SignInPrompt";
+
+import Layout from "./_components/Layout";
+import LeaderboardTabs from "./_components/LeaderboardTabs";
+import OptInToggle from "./_components/OptInToggle";
+import { getLeaderboard } from "./_lib/leaderboard";
+
+// Load-bearing. The Docker image runs `next build` *before* the deploy runs
+// `prisma db push`, so a statically prerendered page would query a
+// `showOnLeaderboard` column that does not exist yet and fail the build.
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Wordleverse Leaderboard | Christopher Salinas Jr.",
+};
+
+export default async function LeaderboardPage() {
+  const data = await getLeaderboard();
+
+  return (
+    <Layout>
+      {data.signedIn ? (
+        <OptInToggle optedIn={data.optedIn} />
+      ) : (
+        <SignInPrompt />
+      )}
+      <LeaderboardTabs {...data} />
+    </Layout>
+  );
+}


### PR DESCRIPTION
Closes #14

## What changed

- **`prisma/schema.prisma`** — `User.showOnLeaderboard Boolean @default(false)`. Additive with a default, so the deploy's `db push --skip-generate` (deliberately without `--accept-data-loss`) accepts it.
- **`leaderboard/_lib/rank.js`** — the pure module where every rule lives: `guessCountOf` (falls back to `row + 1` when `guesses` is null on legacy rows, clamped to 1..6 because the `IQUIT` concede path sets `row: 6`), `initialsOf`, `displayName`, `rankToday`, `rankAllTime`. Competition ranks: equal keys share a rank and the next rank skips. It is also the privacy boundary — `isYou` is resolved here against the viewer's id and the identifiers are then dropped, so no row leaving the module carries an id or an email.
- **`leaderboard/_lib/leaderboard.js`** — `getLeaderboard()`. Both queries filter on `showOnLeaderboard: true`, so an un-opted-in user cannot leak in through either board. Today is `dateFormat(new Date(), "yyyy-mm-dd")`, matching how `saveGame.js` writes `WordleGame.date`. Wrapped in try/catch so a DB hiccup costs the boards, not the page.
- **`leaderboard/_actions/setLeaderboardOptIn.js`** — `"use server"`. Writes the caller's own row only (id from `getCurrentUser()`, never from the argument) and coerces the argument with `Boolean()`.
- **`leaderboard/page.js`** — server component, `dynamic = "force-dynamic"`. Load-bearing: the Docker image runs `next build` before the deploy runs `prisma db push`, so a prerendered page would query `showOnLeaderboard` before the column exists and fail the build. Confirmed `ƒ (Dynamic)` in the build output below.
- **`leaderboard/_components/`** — `Layout`, `LeaderboardTabs` (both datasets arrive as props, so switching tabs makes no request), `TodayBoard`, `AllTimeBoard`, `OptInToggle`, and `Board.jsx` holding the table chrome the two boards share.
- **`(game)/Header.jsx`** — a third nav link, and all three link labels moved into `<span className="label">` hidden under 600px. Hidden with CSS, never by conditional rendering, per the root `CLAUDE.md` note about the Font Awesome kit swapping `<i>` for `<svg>`.
- **`history/_components/Layout.js`** — matching Leaderboard link beside the back link.
- **`wordleverse/CLAUDE.md`** — directory tree entry plus a Leaderboard section recording the opt-in default, the rank.js boundary, the date definition, and why `force-dynamic` must stay.

## How it was verified

    ./node_modules/.bin/prisma format && ./node_modules/.bin/prisma validate
    → The schema at prisma\schema.prisma is valid

    ./node_modules/.bin/prisma generate
    → Generated Prisma Client (v6.19.3)

    npm run lint
    → No ESLint warnings or errors

    npm run build
    → compiled successfully; ƒ /games/wordleverse/leaderboard  16.6 kB  176 kB
      (ƒ = server-rendered on demand — force-dynamic is in effect)

`rank.js` behaviour was checked with a throwaway Node script (not committed — this repo has no test runner and the plan puts one out of scope). Cases covered and passing: guess count from a `guesses` array; `guesses: null` falling back to `row + 1`; the `row: 6` concede clamping to 6; an over-length array clamping to 6; initials from one/two/zero words; blank name → `Anonymous`; today's ordering with wins before losses and a shared rank for two players on 3 guesses followed by rank 4; that a Today row's keys are exactly `rank, name, initials, win, guessCount, expert, isYou` with no id; all-time filtering of zero-played users and `null` average for a player with no wins.

Signed-out page render, `next dev` with an unreachable `DATABASE_URL`:

    curl http://localhost:3111/games/wordleverse/leaderboard
    → 200, containing: "Wordleverse Leaderboard", "Back to Game", "Sign In",
      ">Today<", ">All Time<", "No one has finished today's puzzle yet."
      and *not* containing "Show me on the leaderboard" (correct — signed out).
    → the Prisma connection failure was logged by the catch, not thrown.

    curl http://localhost:3111/games/wordleverse/history
    → 200, contains the /games/wordleverse/leaderboard link.

## Notes for the reviewer

- **I did not run the signed-in manual pass.** It needs the production `DATABASE_URL` and a real session, and step 2 of the plan's manual checklist ("toggle on") is a write to the production `User` table. I verified everything reachable without that (build, lint, signed-out render, and the ranking rules directly) and left the interactive toggle/refresh loop unexercised. The acceptance criteria that depend on a signed-in session are therefore unverified by me: toggle reflects the stored setting, flipping it adds/removes the row, and the `(you)` highlight in a live page.
- **`Board.jsx` is not in the plan's file list.** The plan named `TodayBoard.jsx` and `AllTimeBoard.jsx`; putting the shared `Table`/`Player`/`Empty` chrome in a third file was the alternative to duplicating ~60 lines of styled components across both. Say the word if you would rather see them inlined.
- **`AllTimeRow.played` is computed but not rendered.** The plan puts it in the row shape and lists the columns without it; it is load-bearing for the `played > 0` filter and for `winPct`, so I kept it in the shape rather than dropping it.
- **Column hiding under 700px is a CSS `display: none`**, so avg-guesses and max-streak are still in the payload on a phone. That is deliberate (the plan asks for it) — the rendered data must not depend on the viewport.
- The reused `SignInPrompt` says "Sign in to save your game history across devices!", which is about history rather than the leaderboard. The plan said to reuse it verbatim, so I did; changing its copy would have touched the history page too.
- `getCurrentUser()` is inside the try block, so an auth failure degrades to a signed-out render rather than a 500. The plan only specified wrapping the queries; I extended it one line because `auth()` can throw too.
- `OptInToggle` seeds `useState` from the `optedIn` prop and does not re-sync on later prop changes. After `router.refresh()` the local state and the server value already agree, so this only matters if the row is changed from another tab — in which case the next full load corrects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
