### PR TITLE
fix(wordleverse): make the opt-in failure message tell the truth in both directions

### DIFF
--- a/src/app/(pages)/games/wordleverse/CLAUDE.md
+++ b/src/app/(pages)/games/wordleverse/CLAUDE.md
@@ -115,7 +115,11 @@ Prisma read, with no client fetch.
   on a returned error and in a `catch`. Only a boolean the server confirmed
   survives. For the same reason `getLeaderboard()`'s catch reports `optedIn:
   null`, not `false`: the setting was never read, and "you are not listed" would
-  be a guess. `null` disables the switch and suppresses the notice.
+  be a guess. `null` disables the switch and suppresses the notice. The failure
+  message is direction-aware for the same reason — the revert leaves the user in
+  the state the click tried to leave, so "you are still listed" belongs only to a
+  failed opt-*out*, and both failure paths append the clause, not just the
+  `catch`.
 
 ## Key Invariants
 

--- a/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
+++ b/src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx
@@ -20,8 +20,13 @@ const ErrorMessage = styled.span`
   font-size: 0.9rem;
 `;
 
-const FAILED =
-  "Failed to update leaderboard setting. You are still listed as before.";
+const FAILED = "Failed to update leaderboard setting";
+// Every failure path puts the switch back where it was, so what is true
+// afterwards is the state the click tried to leave. One shared sentence cannot
+// say that: telling somebody whose opt-in failed that they are "still listed"
+// asserts a publication that never happened.
+const STILL_LISTED = "You are still listed on the leaderboard.";
+const NOT_LISTED = "You have not been added to the leaderboard.";
 const UNKNOWN =
   "Could not read your leaderboard setting. Reload to try again.";
 
@@ -50,6 +55,8 @@ const OptInToggle = ({ optedIn }) => {
 
   const onChange = async (event) => {
     const next = event.target.checked;
+    // Both failure paths below revert to `!next`, so this is what is true then.
+    const unchanged = next ? NOT_LISTED : STILL_LISTED;
 
     // Move the switch immediately, put it back unless the server confirms it.
     setChecked(next);
@@ -63,7 +70,7 @@ const OptInToggle = ({ optedIn }) => {
       // returned { error }, or a shape this component does not recognise.
       if (typeof result?.optIn !== "boolean") {
         setChecked(!next);
-        setError(result?.error ?? FAILED);
+        setError(`${result?.error ?? FAILED}. ${unchanged}`);
         return;
       }
 
@@ -77,7 +84,7 @@ const OptInToggle = ({ optedIn }) => {
       // they opted out.
       console.error("Error setting leaderboard opt-in:", error);
       setChecked(!next);
-      setError(FAILED);
+      setError(`${FAILED}. ${unchanged}`);
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
Closes #126

## What changed

Wording only, in `src/app/(pages)/games/wordleverse/leaderboard/_components/OptInToggle.jsx`.

- `FAILED` loses its trailing listing claim and becomes just the reason,
  `"Failed to update leaderboard setting"` (no period — the two strings
  `setLeaderboardOptIn` returns are unpunctuated too, so the template supplies it).
- Two new direction clauses, `STILL_LISTED` / `NOT_LISTED`.
- `onChange` computes `const unchanged = next ? NOT_LISTED : STILL_LISTED;`
  immediately after `next`. Both failure paths revert to `!next`, so `unchanged`
  is by construction what is true once the revert has happened.
- **Both** failure sites append it, not just the `catch`. The
  `typeof result?.optIn !== "boolean"` branch (the `result?.error ?? FAILED`
  fallback) is the path most users actually hit — the server action catches and
  returns rather than throwing — and it previously said nothing about listing at
  all, so fixing only the constant would have left the issue's second Done-when
  unmet on the common path.
- `src/app/(pages)/games/wordleverse/CLAUDE.md`: one sentence appended to the
  existing "The opt-in switch is optimistic…" bullet. No new bullet, no
  restructuring.

Nothing else moved. `UNKNOWN`, `setChecked`, `saving`, `pending`, the `disabled`
logic, the `optedIn == null` path and `setLeaderboardOptIn.js` are byte-identical
to `main` — the fail-closed mechanism verified in the review of #123 was left
alone deliberately.

## How it was verified

    npm ci
    npm run lint
    → ✔ No ESLint warnings or errors

Lint is the only gate this repo has (`package.json` scripts are `dev` / `build` /
`start` / `lint`; `deploy.yml` runs no tests) and the plan explicitly ruled out
adding a test runner for a wording fix. **Lint passing says nothing about the
message text.** So I separately drove the handler, in a throwaway harness that is
not part of this PR:

it loads the real `OptInToggle.jsx` source, transpiles the JSX with the repo's own
`typescript`, stubs the module's imports (React's `useState`/`useTransition`, MUI,
emotion, `next/navigation`, and the server action), pulls the real `onChange` off
the returned element, calls it, and reads back the `error` string and `checked`
value the component would render.

| case | switch after | message |
|---|---|---|
| opt-in, action throws | OFF (was OFF) | `Failed to update leaderboard setting. You have not been added to the leaderboard.` |
| opt-in, `{ error: "Unauthorized" }` | OFF (was OFF) | `Unauthorized. You have not been added to the leaderboard.` |
| opt-in, unrecognised shape `{}` | OFF (was OFF) | `Failed to update leaderboard setting. You have not been added to the leaderboard.` |
| opt-out, action throws | ON (was ON) | `Failed to update leaderboard setting. You are still listed on the leaderboard.` |
| opt-out, `{ error: "Failed to update leaderboard setting" }` | ON (was ON) | `Failed to update leaderboard setting. You are still listed on the leaderboard.` |
| opt-out, `{ error: "Unauthorized" }` | ON (was ON) | `Unauthorized. You are still listed on the leaderboard.` |
| opt-in succeeds (control) | ON (was OFF) | no alert |

No double punctuation in any case, and the switch reverts to the pre-click state
on every failure and sticks only on the confirmed success.

## Notes for the reviewer

Things I would flag at you before you find them:

- **What is still unverified.** The harness stubs React's hooks and MUI, so it
  exercises the handler's logic and the exact strings it sets — it does **not**
  prove React re-renders, that the string reaches the `role="alert"` span, or
  anything about the rendered DOM. I did not load the page in a browser: that
  needs a signed-in session against a live `DATABASE_URL`, which I do not have
  here. The render path is unchanged from `main` (`{error && <ErrorMessage
  role="alert">{error}</ErrorMessage>}`), so I judged the risk there to be nil,
  but I am not claiming to have observed it.
- **Double punctuation is a live hazard for future strings.** The template is
  `` `${reason}. ${unchanged}` ``. Both strings `setLeaderboardOptIn` returns today
  are unpunctuated, so this is correct now; a future error string ending in a
  period would render `"… setting.. You are …"`. I did not add a normalising
  strip, because stripping trailing punctuation from an arbitrary server string
  is more machinery than a two-string call site earns, and the constraint lives
  next to both strings. Say the word if you would rather have the strip.
- **I did not hedge the opt-in message.** If the write commits but the response is
  lost, the user is told they were not added while they actually were. That is the
  same window the pre-existing fail-closed contract already accepts — the switch
  itself asserts `!next` — so hedging the prose while the switch sits confidently
  OFF would be incoherent. This was considered and rejected in the plan; flagging
  it because it is the one case where the new sentence can be wrong.
- **Direction of the error.** For a failed opt-in the message now under-warns
  relative to the old one (it says "not added" rather than "still listed"). That
  is the point of the issue, but it is worth stating explicitly: if you think the
  privacy-safe default is to over-warn in both directions, that is a design
  disagreement with the issue, not with this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
