### PR TITLE
fix(tto): keep board cells square on iOS Safari

### DIFF
--- a/src/app/(pages)/games/tic-tac-overflow/Gameboard.jsx
+++ b/src/app/(pages)/games/tic-tac-overflow/Gameboard.jsx
@@ -9,9 +9,17 @@ const Board = styled.div`
   display: grid;
   gap: 0.5rem;
   /* minmax(0, 1fr), not a bare 1fr: 1fr means minmax(auto, 1fr), whose floor is
-     the items' min-content size, so a single cell that measures taller than its
-     share would silently un-square the whole board. The board's shape is the
-     board's business. */
+     the items' min-content size, so one oversized cell drags its whole column
+     up with it. Pinning that floor to zero stops the feedback loop — while
+     #136's glyph bug was live a marked cell measured 205.34 with a bare 1fr and
+     160.42 with this, and its empty neighbours stayed 125.33 square instead of
+     stretching to match. It does not keep the board square, and no track
+     function can: this box has aspect-ratio with an auto height, which gives it
+     a content-based automatic minimum in the ratio-dependent axis that grid
+     sizing cannot reach, so a cell taller than its share still grows the board
+     — with this guard applied #136 rendered 392 wide by 497.27 tall. Damage
+     control, not a regression check: if you change what lives inside a Cell,
+     measure the board box yourself. */
   grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-template-rows: repeat(3, minmax(0, 1fr));
   /* Square, but never tall enough to push the status line off a short screen. */

--- a/src/app/(pages)/games/tic-tac-overflow/Gameboard.jsx
+++ b/src/app/(pages)/games/tic-tac-overflow/Gameboard.jsx
@@ -8,8 +8,12 @@ const Board = styled.div`
   aspect-ratio: 1 / 1;
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
+  /* minmax(0, 1fr), not a bare 1fr: 1fr means minmax(auto, 1fr), whose floor is
+     the items' min-content size, so a single cell that measures taller than its
+     share would silently un-square the whole board. The board's shape is the
+     board's business. */
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(0, 1fr));
   /* Square, but never tall enough to push the status line off a short screen. */
   width: min(100%, 26rem, calc(100svh - 19rem));
 `;

--- a/src/app/(pages)/games/tic-tac-overflow/components/Glyph.jsx
+++ b/src/app/(pages)/games/tic-tac-overflow/components/Glyph.jsx
@@ -3,7 +3,16 @@ import styled from "@emotion/styled";
 import Mark from "../Mark";
 
 const Svg = styled.svg`
-  height: 100%;
+  /* The glyph must never be what decides how tall a cell is. Its block size
+     comes from its own 1:1 ratio and never from a percentage of the parent:
+     iOS Safari resolves a percentage height against the *border* box of a box
+     sized by aspect-ratio, so height 100% inside Cell's 14% padding came back a
+     whole padding-box too tall and stretched the grid row it was sitting in.
+     Only width may be a percentage here — the inline axis resolves against a
+     definite size and every engine agrees on it. */
+  aspect-ratio: 1 / 1;
+  display: block;
+  height: auto;
   overflow: visible;
   width: 100%;
 

--- a/src/app/(pages)/games/tic-tac-overflow/instructions/page.js
+++ b/src/app/(pages)/games/tic-tac-overflow/instructions/page.js
@@ -40,7 +40,8 @@ const Board = styled.div`
   display: grid;
   flex: 0 0 auto;
   gap: 0.25rem;
-  /* minmax(0, 1fr), not a bare 1fr — see Gameboard.jsx. */
+  /* minmax(0, 1fr), not a bare 1fr — see Gameboard.jsx. It bounds the tracks;
+     it does not keep this board square either. */
   grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-template-rows: repeat(3, minmax(0, 1fr));
   width: 9rem;

--- a/src/app/(pages)/games/tic-tac-overflow/instructions/page.js
+++ b/src/app/(pages)/games/tic-tac-overflow/instructions/page.js
@@ -40,8 +40,9 @@ const Board = styled.div`
   display: grid;
   flex: 0 0 auto;
   gap: 0.25rem;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
+  /* minmax(0, 1fr), not a bare 1fr — see Gameboard.jsx. */
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(0, 1fr));
   width: 9rem;
 
   > div {


### PR DESCRIPTION
Closes #136

## The arithmetic

`Cell`'s `Container` is `aspect-ratio: 1 / 1; width: 100%; padding: 14%`. At a
125.33px column that is a 125.33px border box, 35.09px of vertical padding
(2 x 14% x 125.33), and a 90.24px **content** box.

`Glyph`'s `Svg` was `height: 100%`. Per spec that percentage resolves against
the parent's **content** box -> 90.24, and the cell stays 125.33 tall. That is
what Chrome does. **WebKit resolves it against the parent's aspect-ratio-derived
border box instead** -> 125.33, so the cell measures 125.33 + 35.09 = **160.42**.
Because `Board`'s tracks were a bare `1fr`, every row containing a mark grew by
exactly one cell's worth of vertical padding and the board grew with it.

That is the 427 x 392 board in the reported screenshot against the 392 x 392 it
should be. The empty cells in a marked row do not stretch to fill it
(`align-self: normal` behaves as `start` for a grid item with a preferred aspect
ratio), which is the ragged 35px hole visible under the top-left cell.

## What changed

- **`components/Glyph.jsx`** — the real fix. The `Svg` no longer has a
  percentage in its block axis at all: `width: 100%` (an *inline*-axis
  percentage, which resolves against a definite size and which every engine
  agrees on) plus its own `aspect-ratio: 1 / 1` and `height: auto`. There is
  nothing left for an engine to misresolve. Colour rules and `overflow: visible`
  are untouched.
- **`Gameboard.jsx`** — `repeat(3, minmax(0, 1fr))` on rows and columns. A bare
  `1fr` is `minmax(auto, 1fr)`, floored at the items' min-content size, so one
  oversized cell drags its whole column up with it. Pinning that floor to zero
  stops that feedback loop; it does **not** keep the board box square (see the
  first reviewer note below). The comment on those two lines says exactly that,
  in both directions, so the limit travels with the code.
- **`instructions/page.js`** — same track guard on the two example boards. They
  have the identical shape (`aspect-ratio` cells, `padding: 16%`, same `Glyph`)
  and so were **broken on iPhone in the same way**; they pick the real fix up
  from `Glyph`.

No JS, no logic, no other files.

## How it was verified — and what that does and does not prove

**Read this before treating the green numbers as a fix.** The defect only
manifests in WebKit. Every engine available to me is Chrome, where the *current*
code already renders correctly. So the measurements below prove
**non-regression**, not that iOS is fixed. I have no iPhone and neither does the
reviewer.

What actually argues the fix is correct is **static**: after this change the
glyph's block size contains no percentage, so there is no percentage left for
any engine to resolve against the wrong box.

    $ grep -nE "(height|min-height|max-height):[^;]*%" .../components/Glyph.jsx
    NONE (criterion met)

Confirmed at runtime too, by reading the authored rule out of the CSSOM rather
than trusting a computed pixel value (a computed `height: 90.2656px` cannot tell
you whether the author wrote a percentage):

    glyphHeightAuthored:        ["height: auto"]
    glyphAspectRatio:           "1 / 1"
    anyPercentInGlyphBlockAxis: false

### Anchor: the harness can actually see the defect

A green run means nothing unless the probe can go red. I forced the board
glyph's block size to the value WebKit computes and re-measured, at 440px:

    board        [392, 497.27]     boardSquare: false
    empty cell   [125.33, 125.33]
    marked cell  [125.33, 160.42]  <- the plan predicted 160.42; iPhone measured 160.33

The marked cell reproduces to within 0.09px, and 497.27 is 392 + 3 x 35.09
because this probe marks three rows (the screenshot had one, hence 427). The
instrument sees the bug.

### Measurements (Chrome, `.agent/scripts/shot.mjs`)

Hotseat, marks placed in three different rows:

| viewport | board | cells | glyph | square? |
|---|---|---|---|---|
| 390 | 342 x 342.02 | all 108.66 sq | 78.27 sq | yes, all 9 equal |
| 440 | 392 x 392.03 | all 125.33 sq | 90.27 sq | yes, all 9 equal |

Glyph is 72.02% of the cell width at both — unchanged size, still centred.
440px matches the plan's predicted `[392, 392]` / `125.33` / `90.2x` exactly.

Instructions page @390 — both example boards, 6 glyphs each:
`144 x 144`, square, every cell `45.33 x 45.33`, all equal.

Chip call sites, **measured on `origin/main` and on this branch**:

| call site | before | after |
|---|---|---|
| `Status` chip (1.5rem) | 24 x 24 | 24 x 24 |
| `OnlineBar` chip (1.1rem) | 17.59 x 17.59 | 17.59 x 17.59 |
| board @440 | `[392, 392.03]`, cells 125.33, glyph 90.27 | identical |

In Chrome this change is geometrically a no-op at every call site, which is
exactly what it should be.

    npm run lint    -> No ESLint warnings or errors
    npm run build   -> success (needed `npx prisma generate` first in a fresh worktree)

## Notes for the reviewer

- **`minmax(0, 1fr)` does not, on its own, keep the board box square.** The plan
  said it would (while correctly rejecting it as the fix). My anchor run
  disproves that: with the guard already applied and the glyph forced to
  WebKit's value, the board still grew to 497.27. A box with `aspect-ratio` and
  `height: auto` has a content-based automatic minimum size in the
  ratio-dependent axis, and in the grid container's intrinsic sizing pass the
  `1fr` max behaves as `auto`, so the oversized items still floor the container.
  This does not affect the fix — it only means the guard is weaker insurance
  than advertised. I kept it because it is in the plan and it is still correct
  and free, but nobody should rely on it to catch a recurrence.

  The guard is not worthless, and the comment now quantifies both halves. Same
  forced-glyph run at 440px, bare `1fr` vs `minmax(0, 1fr)`: the board is
  `[392, 497.27]` either way, but the marked cell goes `205.34 -> 160.42` and
  the empty cell `160.42 -> 125.33`. It halves the blast radius of a recurrence
  without preventing one. **This correction now lives in
  `Gameboard.jsx:11-22`** rather than only here, and
  `instructions/page.js:43-44` — which points at `Gameboard.jsx` — carries the
  same caveat inline, so a reader following the pointer cannot pick up the old
  claim that "the board's shape is the board's business".
- **The `OnlineBar` chip was measured synthetically.** Standing up a live room
  needs the DB, so instead I reproduced that chip's box exactly
  (`display: inline-flex; height/width: 1.1rem`, no padding) and put a *real*
  cloned `Glyph` carrying the shipped emotion class into it. It tests the CSS
  rule that changed, but it does not exercise `OnlineBar` itself.
- **`display: block` on the `Svg`** is an addition beyond the two properties the
  headline change needs. It is there so the inline-level default cannot
  contribute a baseline/line-height to the block axis in the two chips. It
  measured identical with and without.
- **Not fixed here, and it is real:** `body { height: 100vh }`
  (`src/app/globals.css:69`). On iOS Safari `100vh` is the *large* viewport, so
  every page on the site is ~86px taller than the visible area. Site-wide,
  separate from what #136 reports, and deliberately out of scope per the plan —
  it wants its own issue.
- The `calc(100svh - 19rem)` width budget in `Gameboard.jsx` is untouched. It
  only ever looked undersized because the board was rendering up to 105px taller
  than square; now that it is genuinely square the budget means what it says.
- The plan's prescribed comment for `Glyph.jsx` was written in markdown. Inside
  an Emotion template literal its backticks need escaping and render as
  `` \`aspect-ratio\` `` in the emitted CSS, so I dropped the backticks and kept
  the wording. The repo's other CSS comments are plain prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

