### PR TITLE
docs: P1012 is not a database problem -- a fresh checkout needs npm ci

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,31 @@ GAME_ROOM_RATE_LIMIT        # optional; room creations/minute/IP for POST /api/r
 ## Development
 
 ```bash
+npm ci           # install first -- a fresh checkout has no node_modules; see below
 npm run dev      # start dev server on localhost:3000
 npx prisma studio  # inspect DB
 npx prisma db push # apply schema changes
 ```
+
+`npx prisma` in a checkout with no `node_modules` fails with **`P1012`** underlining
+`url = env("DATABASE_URL")` at `prisma/schema.prisma:13`, which reads like "I can't reach
+the database". It isn't. With nothing installed locally, `npx` has no pinned CLI to
+resolve and downloads the latest Prisma (7.x) instead of the 6.19.3 in
+`package-lock.json`; 7.x no longer accepts `url` inside a `datasource` block. The schema
+is correct — the CLI is the wrong major. Run `npm ci`.
+
+Diagnose from the `error:` text and the `Prisma CLI Version :` line at the foot of the
+output, **not** from the code or the line number: `P1012` at `schema.prisma:13` has at
+least three unrelated causes, all of which this repo produces.
+
+| `error:` says | Cause | Fix |
+|---|---|---|
+| ``The datasource property `url` is no longer supported in schema files.`` | `npx` fetched Prisma 7.x — the `Prisma CLI Version` line will say `7.x`, not `6.x` | `npm ci` |
+| `Environment variable not found: DATABASE_URL.` | `DATABASE_URL` is unset | set it |
+| ``Error validating datasource `db`: the URL must start with the protocol `mysql://`.`` | `DATABASE_URL` is set to something that isn't a MySQL URL | fix the value |
+
+The last two are genuine environment problems and `npm ci` fixes neither, so read the
+message before reaching for a fix.
 
 ## Important Patterns
 

--- a/src/lib/realtime/README.md
+++ b/src/lib/realtime/README.md
@@ -202,6 +202,8 @@ await send({ type: "PLACE", cell: 4 }, { optimistic: true });
 ## Local development
 
 There is no MySQL in the repo's dev setup by default; `docker compose up db`
-provides one. Apply the schema with `npx prisma db push`. In production the
-deploy workflow runs `prisma db push --skip-generate` against the freshly built
-image *before* the app serves traffic.
+provides one. Apply the schema with `npx prisma db push` — run `npm ci` first in a
+fresh checkout, or `npx` fetches a Prisma major this schema does not support and fails
+with a `P1012` that looks like a connection error (`CLAUDE.md` → Development). In
+production the deploy workflow runs `prisma db push --skip-generate` against the
+freshly built image *before* the app serves traffic.


### PR DESCRIPTION
Closes #159

Documentation only — no shipped code changes.

## What changed

- **`CLAUDE.md`, `## Development`** — `npm ci` is now the first line of the command fence (`# install first -- a fresh checkout has no node_modules; see below`), followed by the warning the issue asks for, written symptom → cause → fix for a reader who is already mid-misdiagnosis: `npx prisma` with no `node_modules` fails with **`P1012`** underlining `url = env("DATABASE_URL")` at `prisma/schema.prisma:13`, which reads as a connection failure; the actual cause is `npx` having no pinned CLI to resolve and downloading Prisma 7.x instead of the 6.19.3 in `package-lock.json`.
- The warning **does not** say "`P1012` means you forgot `npm ci`." That would be a third wrong diagnosis wearing the authority of documentation. `P1012` at `schema.prisma:13` has at least three unrelated causes — same code, same underlined line, three different `error:` texts — so the doc gives them as a table and tells the reader to diagnose from the **`error:` text** and the **`Prisma CLI Version :`** line at the foot of the output, not from the code or the line number. It says explicitly that `npm ci` fixes neither of the other two.
- **`src/lib/realtime/README.md`, "Local development"** — one sentence beside its `npx prisma db push` line pointing at `CLAUDE.md` → Development. Deliberately not a second copy of the explanation.

Per the architect's audit, the other four `npx` occurrences (`Dockerfile:8`, `.github/workflows/deploy.yml:32`, `.agent/scripts/rc-ending.mjs:27`, and `package.json`'s bare `next` scripts) are untouched — each either runs after `npm ci` in the same stage, runs inside a built image, or fails unambiguously.

## How it was verified

All three `P1012` variants reproduced in this worktree, against this repo's real `prisma/schema.prisma`. Every `error:` string in the table is copied from output below, not paraphrased.

**1. Prisma 7 via `npx`, no `node_modules`** — the trap:

    $ npx --yes prisma --version
    prisma               : 7.9.1
    @prisma/client       : ^6.19.3
    Schema Engine        : ... (at ..\AppData\Local\npm-cache\_npx\...)

    $ npx --yes prisma validate
    Error code: P1012
    error: The datasource property `url` is no longer supported in schema files. ...
      -->  prisma\schema.prisma:13
    13 |   url      = env("DATABASE_URL")
    Prisma CLI Version : 7.9.1

**2. `npm ci`, then the same command** — the pinned CLI, this worktree's provisioned `.env`:

    $ npm ci && npx prisma validate
    Error code: P1012
    error: Error validating datasource `db`: the URL must start with the protocol `mysql://`.
      -->  prisma\schema.prisma:13
    Prisma CLI Version : 6.19.3

**3. Pinned CLI, no `DATABASE_URL`** (schema copied to an empty scratch dir so no `.env` is found):

    $ .../node_modules/.bin/prisma validate
    Error code: P1012
    error: Environment variable not found: DATABASE_URL.
      -->  prisma\schema.prisma:13
    Prisma CLI Version : 6.19.3

Diff scope:

    $ git diff --stat
     CLAUDE.md                  | 21 +++++++++++++++++++++
     src/lib/realtime/README.md |  8 +++++---

Self-check the issue demands: staring at output 1, the new text names `P1012`, says it looks like a connection problem, and sends me to `Prisma CLI Version : 7.9.1` → `npm ci`. Doing that lands on output 2, which the same table identifies as a *different* failure `npm ci` will not fix. Both hops are ones the doc actually makes.

## Notes for the reviewer

- **Output 2 is worth dwelling on.** It is what an agent gets in a correctly provisioned worktree that *did* run `npm ci`. If the doc had reduced to "`P1012` → run `npm ci`", the very next thing the reader hits after following it is another `P1012` the advice does not explain — which is why the `error:`-text-not-code framing is the load-bearing part of this change and not hedging.
- The table is a mild style deviation: `CLAUDE.md` is otherwise fences and prose bullets, no tables. I used one because "identical code, identical line, three different messages" is the point, and a table shows that structurally in a way three sentences don't. Easy to flatten to bullets if you'd rather.
- The Prisma 7 `error:` text is quoted only as far as its first sentence; the real message continues into `prisma.config.ts` / Accelerate advice. The first sentence is enough to match on and the full one would not fit a table cell.
- `7.9.1` is what `npx` resolved today. The doc says "the latest Prisma (7.x)" rather than pinning that number so it doesn't rot; the exact version only appears here.
- No build or test run: this PR changes no shipped code, and the plan's Verification section is `git diff --stat`. `npm ci` was run anyway, purely to reproduce variants 2 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
