### PR TITLE
docs: describe the player token cookie's retention and stop enumerating the online games

### DIFF
--- a/src/app/(pages)/privacy-policy/page.js
+++ b/src/app/(pages)/privacy-policy/page.js
@@ -9,7 +9,7 @@ const PrivacyPolicy = () => {
       <Title>Privacy Policy</Title>
 
       <Typography variant="h4" component="h2" gutterBottom>
-        Last Updated: August 3, 2026
+        Last Updated: August 16, 2026
       </Typography>
 
       <Typography variant="body1" paragraph>
@@ -49,7 +49,7 @@ const PrivacyPolicy = () => {
       </Typography>
 
       <Typography variant="body1" paragraph>
-        Tic-Tac-Overflow, Edge Case, Connect 404 and Race Condition can be played online against other people. Playing online creates a room — one database row, identified by a four-character code — holding the game in progress and, for each player, a seat number, a colour, a display name, and the times they joined and were last seen. No account is involved, and nothing in a room is linked to one even if you happen to be signed in.
+        Several of the games can be played online against other people. Playing online creates a room — one database row, identified by a four-character code — holding the game in progress and, for each player, a seat number, a colour, a display name, and the times they joined and were last seen. No account is involved, and nothing in a room is linked to one even if you happen to be signed in.
       </Typography>
 
       <Typography variant="body1" paragraph>
@@ -61,11 +61,11 @@ const PrivacyPolicy = () => {
       </Typography>
 
       <Typography variant="body1" paragraph>
-        Edge Case asks for a display name in its lobby and remembers your last one in your browser; Tic-Tac-Overflow, Connect 404 and Race Condition do not ask, and call you by your seat or your colour. Whatever you type is shown to everyone in the room, so treat it as public and do not put anything in it you would not want a stranger to read.
+        Edge Case asks for a display name in its lobby and remembers your last one in your browser. The other online games do not ask, and call you by your seat or your colour. Whatever you type is shown to everyone in the room, so treat it as public and do not put anything in it you would not want a stranger to read.
       </Typography>
 
       <Typography variant="body1" paragraph>
-        The Website needs some way to tell which browser holds which seat, and it does not use an account for that. The first time you play online, your browser generates a random identifier and saves it under CSALINAS-PLAYER-TOKEN in both local storage and a cookie of the same name — either one alone is enough, and keeping both is what stops a refresh in a private window turning you into a different player. It travels with your moves so the server can work out whose turn was just taken, which is also how you get your seat back after a refresh or a dropped connection.
+        The Website needs some way to tell which browser holds which seat, and it does not use an account for that. The first time you open an online game — playing or watching — your browser generates a random identifier and saves it under CSALINAS-PLAYER-TOKEN in both local storage and a cookie of the same name — either one alone is enough, and keeping both is what stops a refresh in a private window turning you into a different player. It travels with your moves so the server can work out whose turn was just taken, which is also how you get your seat back after a refresh or a dropped connection.
       </Typography>
 
       <Typography variant="body1" paragraph>
@@ -169,6 +169,7 @@ const PrivacyPolicy = () => {
         <ListItem>Streaming tickets and rate limit counters — seconds to a minute, in memory only</ListItem>
         <ListItem>Your account and its Wordleverse history — for as long as the account exists</ListItem>
         <ListItem>Anything in local storage — until you clear it</ListItem>
+        <ListItem>The CSALINAS-PLAYER-TOKEN cookie — one year, renewed each time you open an online game, or until you clear it</ListItem>
       </List>
 
       <Typography variant="body1" paragraph>

--- a/src/app/(pages)/terms/page.js
+++ b/src/app/(pages)/terms/page.js
@@ -9,7 +9,7 @@ const TermsAndConditions = () => {
       <Title>Terms and Conditions</Title>
 
       <Typography variant="h4" component="h2" gutterBottom>
-        Last Updated: August 3, 2026
+        Last Updated: August 16, 2026
       </Typography>
 
       <Typography variant="body1" paragraph>
@@ -65,7 +65,7 @@ const TermsAndConditions = () => {
       </Typography>
 
       <Typography variant="body1" paragraph>
-        Tic-Tac-Overflow, Edge Case, Connect 404 and Race Condition can be played online with other people. Each game lives in a room with a four-character code, and anyone holding that code can join it or watch it. Codes are listed nowhere, but they are short and they are not secret — share one only with the people you mean to play with.
+        Several of the games can be played online with other people. Each game lives in a room with a four-character code, and anyone holding that code can join it or watch it. Codes are listed nowhere, but they are short and they are not secret — share one only with the people you mean to play with.
       </Typography>
 
       <Typography variant="body1" paragraph>


### PR DESCRIPTION
Closes #149

Prose-only change to `/privacy-policy` and `/terms`. Every edited sentence describes
behaviour that already shipped; nothing here adds, broadens, or narrows a commitment
about visitor data.

Note the plan's framing: both headline inaccuracies named in the issue body were
already fixed in passing by PR #147, so this PR is the smaller remainder.

## What changed

- **`privacy-policy/page.js` — Data Retention gains the cookie.** This is the one real
  factual gap left. The list covered local storage and said nothing about the
  `CSALINAS-PLAYER-TOKEN` cookie, which holds the same identifier for a year
  (`TOKEN_COOKIE_MAX_AGE`, `src/lib/realtime/useRoom.js:25`). The new item says
  "one year, renewed each time you open an online game" because `getPlayerToken`
  re-asserts the value to both stores on *every* read (`useRoom.js:76-81`) — the year
  runs from your last online game, not from the first, which a visitor would not guess
  from a bare "one year".
- **`privacy-policy/page.js` — the identifier is minted by watching too.** The
  paragraph said "the first time you play online". The effect that calls
  `getPlayerToken` guards only on `code` (`useRoom.js:209-213`); the `spectate` branch
  is downstream at line 378, so a spectator mints and stores the identifier exactly as
  a player does. Now reads "the first time you open an online game — playing or
  watching —". The rest of that paragraph (both stores, why both) is untouched.
- **Both pages — the online games become a category, Edge Case stays named.**
  "Tic-Tac-Overflow, Edge Case, Connect 404 and Race Condition can be played
  online…" → "Several of the games can be played online…" on both pages. Edge Case
  remains named in the display-name paragraph, because it is the only game that asks
  for one — a genuine privacy distinction rather than a feature list. This is the
  drift fix: the enumeration went stale at Connect 404 and again at Race Condition,
  and would have gone stale at the next online game.
- **Both pages — `Last Updated` → August 16, 2026.** It was stale from #147's edits as
  well as these; the policy's own "Changes" section says the date is how a visitor is
  told something moved. Same date on both files.

Diff is 7 insertions / 6 deletions across two files. No structural or component change.

## How it was verified

Code claims checked against source before writing prose:

    src/lib/realtime/useRoom.js:25       TOKEN_COOKIE_MAX_AGE = 60*60*24*365  (one year)
    src/lib/realtime/useRoom.js:62-87    getPlayerToken: localStorage -> cookie -> mint,
                                         then re-asserts to BOTH on every read
    src/lib/realtime/useRoom.js:209-213  token minted whenever `code` is set; the
                                         `spectate` branch is at :378, downstream of it
    src/lib/realtime/registry.js         four registered online games
    src/lib/realtime/players.js:67-69    cleanName defaults to "Player N", so "a display
                                         name" per player is true of all four games

Build and lint:

    npm ci
    npx prisma generate          # needed before the build in a fresh worktree
    npm run lint                 # ✔ No ESLint warnings or errors
    npm run build                # ✓ compiled; /privacy-policy and /terms prerendered

Rendered output read end to end as a visitor would, by stripping tags from the
prerendered `.next/server/app/{privacy-policy,terms}.html`: both pages show
"Last Updated: August 16, 2026", both open their online-games section with "Several of
the games…", the identifier paragraph reads "playing or watching", and Data Retention
carries the new cookie item. No game name survives as an online-game enumeration on
either page.

## Notes for the reviewer

- **Two mentions of game names remain in the privacy policy and are deliberate**:
  `TICTACOVERFLOW-PREVIEW` and `EDGECASE-NAME` in the local-storage key list, where the
  name identifies which key belongs to what. Those are storage keys, not an
  online-games enumeration, and they go stale only if the keys themselves change.
- **The issue body states a wrong reason for the cookie** — that it is what makes
  `sendBeacon`-on-`pagehide` work. It is not: that handler reads the token from
  `tokenRef.current` in memory (`useRoom.js:564-577`). The cookie exists because
  `localStorage` can be unavailable, where the old module-scoped fallback minted a
  fresh UUID per page load and stranded your seat (#105). The sentence already on the
  page states that reason correctly, so I left it alone and did not import the issue's
  version into the prose.
- **What the category phrasing costs**: a visitor can no longer tell from the policy
  alone which games are online. Accepted per the plan — the games themselves say so,
  and every claim in those two sections holds for all four (same room, same code, same
  60-minute expiry, same identifier; only Edge Case asks for a name).
- **Deliberately not touched**: the Hygraph sentence, which is stale in a small way
  (there are no project pages; `src/lib/hygraph.js` is consumed only by
  `games/mini-motorways/action.js`). It sits in the paragraph #154 rewrites and the
  architect raised it there.
- **Sequencing**: #154 also edits `privacy-policy/page.js`, adding `substackcdn.com` to
  the Third-Party Services list. Different paragraphs, so it should rebase cleanly onto
  this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
