### PR TITLE
docs: say the blog mirror is visit-triggered, not on a schedule

### DIFF
--- a/src/app/(pages)/privacy-policy/page.js
+++ b/src/app/(pages)/privacy-policy/page.js
@@ -146,7 +146,7 @@ const PrivacyPolicy = () => {
       </List>
 
       <Typography variant="body1" paragraph>
-        Two things on the Website are written somewhere else and fetched by my server rather than by your browser: the Mini Motorways page&apos;s data, which comes from Hygraph, and the text of the blog posts that started life on my Substack newsletter, which my server collects on a schedule and stores. Your browser never contacts either one to read a post here.
+        Two things on the Website are written somewhere else and fetched by my server rather than by your browser: the Mini Motorways page&apos;s data, which comes from Hygraph, and the text of the blog posts that started life on my Substack newsletter, which my server copies into its own database. Somebody opening the blog is what sends the server looking for new posts, and it goes after your page has already been sent, so no visitor waits on it. However many people are reading, it fetches no more than once every ten minutes — and on a day when nobody opens the blog, nothing is fetched at all. Deploying a new version of the Website fetches once as well. Your browser never contacts either one for the words of a post.
       </Typography>
 
       <Typography variant="body1" paragraph>


### PR DESCRIPTION
Closes #170

One paragraph on `/privacy-policy`, one line of diff. Everything else on the page was verified by the architect against the code and left alone.

## What changed

- **"on a schedule" → visit-triggered, throttled, plus a deploy sync.** The old phrasing described the design #154 planned, not the one #168 shipped. The replacement says what actually happens, in the order a reader needs it: the server copies the post text into its own database; somebody opening the blog is what sends it looking; the fetch goes after the response so no visitor waits on it; it fetches no more than once every ten minutes however many people are reading; **and on a day when nobody opens the blog, nothing is fetched at all**. That last clause is the property a visitor could not guess and the one "on a schedule" actively inverted. The deploy sync is named separately, because it is the one half that really is visitor-independent.
- **The closing clause is narrowed from "to read a post here" to "for the words of a post".** Three lines above it a bullet says `substackcdn.com` serves post images and therefore sees your IP. Both statements were individually true — images stay as literal CDN `<img>` URLs, the Hygraph-backed page goes through `next/image` — but read in sequence they looked like a contradiction. Scoping the clause to the text resolves it and now reads as a deliberate contrast with the bullet's "the images in them".
- **The Hygraph half of the sentence is untouched**, verbatim.
- **"Last Updated" already reads August 16, 2026**, which is the day this ships, so it is correct as-is. Per the plan I did not bump it to a date in the future to make the diff look bigger.

## How it was verified

    npm ci
    npm run lint
    → ✔ No ESLint warnings or errors     (react/no-unescaped-entities is the one that matters here; no new apostrophes were introduced)

    npm run dev -- -p 3170
    curl -s http://localhost:3170/privacy-policy
    → rendered the "Third-Party Services" section to plain text and read it end to end,
      bullet list and paragraph together, rather than reading the diff

Reading it in sequence in the running page, the CDN bullet ("serves the images in them") and the paragraph's close ("never contacts either one for the words of a post") now agree instead of appearing to disagree. "Last Updated: August 16, 2026" confirmed in the rendered HTML.

`git diff --stat` → `src/app/(pages)/privacy-policy/page.js | 2 +-`, one file.

## Notes for the reviewer

- **The promise test.** Everything in the new sentence is in the indicative and describes today's behaviour: "it fetches no more than once every ten minutes" is a fact about the current constant, not an undertaking to keep it at ten. A future change to `REFRESH_INTERVAL_MS` would *outdate* this sentence, the same way a code change outdates any description — it would not *break* a commitment, because none is made. No retention period is claimed for mirrored posts and no minimum or maximum is promised. If you read any clause as an assurance rather than a description, that is the thing to flag.
- **The one judgement call worth naming:** I said "on a day when nobody opens the blog, nothing is fetched at all" as a plain consequence rather than as a privacy feature. It is the most reassuring fact in the paragraph and it would have been easy to sell it; selling it would have turned a description into a promise, so it is stated flat.
- **Paragraph length.** The Substack half now carries four clauses where it carried one, so the paragraph is noticeably longer than its neighbours. The plan permitted splitting it, and I kept it as one paragraph because the Hygraph and Substack halves share the "fetched by my server, not your browser" premise and the closing clause covers both. If you would rather see it split, that is a formatting preference and easy to change.
- No behaviour changed. Nothing under `src/lib/substack/` was touched, and there is no test to add — the file is a static MUI component and the repo has no test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
